### PR TITLE
fix: 배포 환경(MySQL) 호환성 문제 해결 (예약어 충돌 및 PK 길이 조정)

### DIFF
--- a/src/main/java/com/retrip/auth/domain/entity/Authority.java
+++ b/src/main/java/com/retrip/auth/domain/entity/Authority.java
@@ -19,7 +19,7 @@ public class Authority extends BaseEntity {
     @Column(columnDefinition = "varbinary(16)")
     private UUID id;
 
-    @Column(name = "grant", length = 50, nullable = false)
+    @Column(name = "is_granted", length = 50, nullable = false)
     private AuthorityGrant grant;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/retrip/auth/domain/entity/RefreshToken.java
+++ b/src/main/java/com/retrip/auth/domain/entity/RefreshToken.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 public class RefreshToken {
 
     @Id
-    @Column(length = 1024)
+    @Column(length = 700)
     private String tokenValue;
 
     private String memberId;


### PR DESCRIPTION
## 🔍 PR 타입 선택

아래 타입 중 해당하는 하나를 선택해 주세요. 반드시 하나만 선택해 주세요.

- [ ] `feat`: 새로운 기능 추가
- [ ] `fix`: 버그 수정
- [ ] `docs`: 문서 수정
- [ ] `style`: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] `refactor`: 코드 리팩토링
- [ ] `test`: 테스트 코드 추가 또는 수정
- [ ] `chore`: 빌드 업무 수정, 패키지 매니저 수정 등 기타 작업


## 📝 변경 사항 요약

배포 서버(MySQL)에서 발생한 테이블 생성 오류를 수정함.
H2(인메모리) 환경과 달리 MySQL의 문법 및 제약조건(Strict Mode)으로 인해 발생한 이슈 해결.

1. Authority 엔티티 수정
- 원인: 'grant'는 MySQL의 권한 부여 예약어(Reserved Keyword)로 컬럼명 사용 불가.
- 해결: @Column(name = "is_granted") 어노테이션을 추가하여 DB 컬럼명을 'is_granted'로 변경 매핑.

2. RefreshToken 엔티티 수정
- 원인: PK인 tokenValue의 길이가 1024로 설정됨. MySQL(utf8mb4) 기준 인덱스 최대 크기(3072 bytes)를 초과하여 테이블 생성 불가.
  (1024 chars * 4 bytes = 4096 bytes > 3072 bytes)
- 해결: 길이를 700자로 축소 (@Column(length = 700))하여 인덱스 생성 가능 범위로 조정.


## 🛠 관련 이슈

Resolves: #123  
Ref: #456  
Related to: #48, #45
close: #번호

### **추가 설명 (선택 사항)**

변경 사항에 대한 추가 설명을 작성해 주세요.
