### PR TITLE
feat: 다중 소셜 로그인 연동, 닉네임, JWT 클레임 버그 수정 및 API 명세 v2.2

### DIFF
--- a/.claude/memory-bootstrap/MEMORY.md
+++ b/.claude/memory-bootstrap/MEMORY.md
@@ -1,0 +1,7 @@
+# MEMORY INDEX
+
+- [user_profile.md](user_profile.md) — Retrip 팀 auth 도메인 담당 개발자 프로필
+- [project_retrip_overview.md](project_retrip_overview.md) — Retrip 팀 프로젝트 전체 구조 및 도메인 개요
+- [project_auth_implementation.md](project_auth_implementation.md) — auth 도메인 구현 현황 및 핵심 설계 결정사항
+- [project_deployment_task.md](project_deployment_task.md) — 내일 주력 작업: 테스트→운영 배포 전환
+- [feedback_work_style.md](feedback_work_style.md) — 협업 방식 및 피드백

--- a/.claude/memory-bootstrap/feedback_work_style.md
+++ b/.claude/memory-bootstrap/feedback_work_style.md
@@ -1,0 +1,29 @@
+---
+name: 협업 방식 및 피드백
+description: 이 개발자와 작업할 때의 스타일 가이드 및 주의사항
+type: feedback
+---
+
+## 응답 스타일
+
+- 답변은 짧고 직접적으로. 불필요한 전제나 재확인 없이 바로 핵심
+- 코드 수정 시 파일 전체보다 변경 부분 위주로 설명
+- 설계 결정을 내릴 때는 근거(업계 표준, 타 서비스 사례)를 함께 제시
+- 한국어로 소통
+
+**Why:** 개발자가 이미 맥락을 알고 있으므로 재설명보다 빠른 실행을 선호.
+**How to apply:** 질문에는 바로 답하고, 확인이 필요한 경우에만 질문.
+
+## 코드 작업 시 주의사항
+
+- 팀원 코드(searchMembers, getMembersByIds, ImageService 등)는 건드리지 말 것
+- 헥사고날 아키텍처 패키지 구조 준수 (controller는 infra, usecase는 application/in)
+- `hasPassword()` 패턴 일관 사용 — `provider == "local"` 비교 방식 사용 금지
+- 소셜 유저 관련 로직은 항상 `hasPassword()` 분기로 처리
+- DB: 로컬은 H2, 운영은 MySQL — 방언 차이 주의 (JPQL 사용 권장, native query 지양)
+
+## 세션 간 컨텍스트 인계
+
+- 이 파일들(`memory-bootstrap/`)을 읽으면 이전 세션의 전체 컨텍스트를 복원할 수 있음
+- 새 기기에서 세션 시작 시: "memory-bootstrap 폴더를 읽고 이 기기 메모리에 저장해줘"
+- 읽기 완료 후 bootstrap 파일은 삭제하거나 .gitignore에 추가

--- a/.claude/memory-bootstrap/project_auth_implementation.md
+++ b/.claude/memory-bootstrap/project_auth_implementation.md
@@ -1,0 +1,128 @@
+---
+name: auth 도메인 구현 현황
+description: auth 도메인의 핵심 설계 결정사항, 구현 완료 내용, 주의사항
+type: project
+---
+
+## 현재 브랜치
+
+`feat/social-login-multi-provider-nickname` (2026-04-02 커밋, develop PR 오픈 중)
+
+---
+
+## 핵심 설계 결정사항 (팀 합의 완료)
+
+| 항목 | 결정 | 근거 |
+|------|------|------|
+| 소셜 연동 | 이메일 기준 자동 연동 (Supabase 방식) | 1계정 N소셜 지원, Auth0/Firebase 표준 |
+| 소셜 저장 | `member_social_provider` 별도 테이블 | `Member.providerId` 단일 필드 방식 폐기 |
+| `Member.provider` 의미 | 마지막 로그인 방식 추적 ("local"/"kakao"/...) | 가입 방식이 아님 — 중요! |
+| 소셜 비밀번호 | DB null (소셜 서비스가 관리) | 소셜 유저는 SET 가능, CHANGE 불가 |
+| 닉네임 | 가입 시 선택 입력, 미입력 시 이름 자동 대체 | JWT claims에 `nickname` 포함 필수 |
+| Access Token | 30분 | 업계 표준 (기존 120분에서 변경) |
+| Refresh Token | 14일 | 업계 표준 (기존 2년에서 변경) |
+| 알림 설정 | 마스터 토글만 구현 | 세부 토글은 차기 배포 |
+
+---
+
+## DB 스키마 변경 (이번 PR)
+
+### 신규: `member_social_provider`
+```sql
+CREATE TABLE member_social_provider (
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id   VARBINARY(16) NOT NULL,
+    provider    VARCHAR(20)   NOT NULL,   -- 'kakao'|'naver'|'google'
+    provider_id VARCHAR(255)  NOT NULL,   -- 소셜 서비스 고유 ID
+    email       VARCHAR(50),
+    linked_at   DATETIME(6)   NOT NULL,
+    UNIQUE KEY uk_member_provider (member_id, provider),
+    UNIQUE KEY uk_provider_provider_id (provider, provider_id)
+);
+```
+
+### `member` 테이블 변경
+- `provider_id` 컬럼 **제거** (member_social_provider로 이전)
+- `nickname` 컬럼 **추가** VARCHAR(15)
+
+---
+
+## 구현 완료 파일 목록
+
+### 신규 파일
+- `domain/entity/MemberSocialProvider.java` — 소셜 연동 엔티티
+- `application/out/repository/MemberSocialProviderRepository.java`
+- `application/in/request/SetInitialPasswordRequest.java` — 소셜→로컬 비밀번호 설정
+
+### 주요 수정 파일
+
+**`domain/entity/Member.java`**
+- `providerId` 필드 제거
+- `nickname` 필드 추가
+- `hasPassword()` — `getPasswordValue() != null`
+- `setPassword()` — PASSWORD_ALREADY_EXISTS 체크 후 설정
+- `updateLastLoginProvider(String provider)` — 로그인 시마다 호출
+- `updateNickname(String nickname)`
+- `createSocialMember()` — providerId 파라미터 제거
+
+**`application/config/JwtProvider.java`**
+- `generateTokens()`, `createToken()`, `getAuthentication()` 모두 `nickname` claim 추가
+
+**`application/in/CustomOAuth2UserService.java`**
+- `saveOrUpdate()` 3단계 로직:
+  1. providerId 기준 재로그인 → `updateLastLoginProvider`
+  2. 이메일 기준 계정 연동 → 새 MemberSocialProvider 저장
+  3. 신규 가입 → Member + MemberSocialProvider 저장
+
+**`application/config/OAuth2LoginSuccessHandler.java`**
+- `@Value("${app.frontend-callback-url}")` 환경변수화 (하드코딩 제거)
+- `authService.saveRefreshToken()` 호출 추가 (버그 수정 — 기존엔 DB 저장 안 됨)
+
+**`infra/adapter/in/rest/filter/LoginAuthenticationFilter.java`**
+- `successfulAuthentication()` 에서 `member.updateLastLoginProvider("local")` 추가
+
+**`application/in/MemberService.java`**
+- `deleteUser()` — `hasPassword()` 분기 (소셜 유저 NPE 버그 수정)
+- `updateUser()` — `isVerified` 잠금 + `hasPassword()` 분기
+- `changePassword()` — `!hasPassword()` → Member-007
+- `setInitialPassword()` — 신규 (소셜→로컬 비밀번호 설정)
+- 팀원 추가 메서드 `searchMembers()`, `getMembersByIds()` 유지
+
+**`infra/adapter/in/rest/in/MemberController.java`**
+- `POST /users/password` 추가 — setInitialPassword 호출
+
+---
+
+## 에러 코드 현황
+
+| 코드 | HTTP | 메시지 |
+|------|------|--------|
+| Member-001 | 401 | 멤버 엔티티를 찾을 수 없습니다 |
+| Member-002 | 401 | 비밀번호가 다릅니다 |
+| Member-003 | 400 | 탈퇴한 이메일은 재가입할 수 없습니다 |
+| Member-004 | 409 | 이미 존재하는 이메일입니다 |
+| Member-005 | 409 | 이미 가입된 정보입니다 (CI 중복) |
+| Member-006 | 400 | 본인인증 완료 후 이름/생년월일 변경 불가 |
+| Member-007 | 403 | 소셜 로그인 계정은 비밀번호 변경 불가 |
+| Member-008 | 409 | 이미 비밀번호가 설정된 계정 |
+| Image-001 | 400 | 지원하지 않는 이미지 확장자 (팀원 추가) |
+
+---
+
+## 미처리 항목 (주의)
+
+- `DebugController.java` — refresh token 전체 노출, **운영 배포 전 반드시 삭제**
+- `application local.yml`, `application.yml.backup`, `new.toml`, `new2.toml` — 로컬 임시 파일, 커밋 제외됨
+
+---
+
+## 스펙 문서 위치
+
+- `C:\Users\p_caso\IdeaProjects\wireframe\spec.html` — Auth API + 화면 상태 명세
+- `C:\Users\p_caso\IdeaProjects\wireframe\index.html` — 와이어프레임 (모바일 화면)
+
+**스펙과 현재 구현의 차이 (의도적 변경)**
+- 토큰 만료: 스펙은 120분/2년 → 구현은 30분/14일 (팀 합의로 변경)
+- GET /users/me 응답: `provider` → `lastLoginProvider` 로 필드명 변경 (프론트 수정 필요)
+- ProfileResponse: `linkedProviders`, `hasPassword` 추가 (스펙 미반영, 프론트 협의 필요)
+- nickname 필드 추가 (스펙 미반영)

--- a/.claude/memory-bootstrap/project_deployment_task.md
+++ b/.claude/memory-bootstrap/project_deployment_task.md
@@ -1,0 +1,113 @@
+---
+name: 운영 배포 전환 작업 (2026-04-03 주력 과제)
+description: 테스트 환경에서 운영 배포 환경으로 전환하는 작업 내용 및 체크리스트
+type: project
+---
+
+## 목표
+
+테스트 API 키 → 운영 API 키로 교체하고, 소셜 로그인 / PortOne 인증이 실제 환경에서 정상 동작하도록 배포 설정 완전 전환.
+
+**Why:** 현재는 각 서비스 테스트(개발) 키로 동작 중 — 카카오 개발앱, 네이버 테스트 앱, PortOne 테스트 모드 등. 실제 사용자 대상 서비스를 위해 운영 키로 전환 필요.
+
+---
+
+## 환경변수 전환 체크리스트
+
+### JWT (RS256 키 쌍)
+- [ ] `JWT_PRIVATE_KEY` — RSA 개인키 (PEM 또는 Base64)
+- [ ] `JWT_PUBLIC_KEY` — RSA 공개키
+
+> 키 생성: `openssl genrsa -out private.pem 2048` → `openssl rsa -in private.pem -pubout -out public.pem`
+> 환경변수에는 개행 제거 또는 Base64 인코딩 후 저장
+
+### Google OAuth2
+- [ ] `GOOGLE_CLIENT_ID` — Google Cloud Console에서 운영용 OAuth 앱 생성
+- [ ] `GOOGLE_CLIENT_SECRET`
+- 승인된 리다이렉트 URI 추가 필요: `https://api.retrip.io/login/oauth2/code/google`
+
+### 카카오 OAuth2
+- [ ] `KAKAO_CLIENT_ID` — 카카오 개발자 콘솔 → 앱 생성 → REST API 키
+- [ ] `KAKAO_CLIENT_SECRET` — 카카오 앱 → 보안 → Client Secret
+- Redirect URI 등록 필요: `https://api.retrip.io/login/oauth2/code/kakao`
+- 동의항목: `profile_nickname`, `account_email` 비즈니스 검수 여부 확인
+
+### 네이버 OAuth2
+- [ ] `NAVER_CLIENT_ID` — 네이버 개발자 센터 → 앱 등록
+- [ ] `NAVER_CLIENT_SECRET`
+- Redirect URI 등록 필요: `https://api.retrip.io/login/oauth2/code/naver`
+
+### PortOne V2 (본인인증)
+- [ ] `PORTONE_STORE_ID` — PortOne 콘솔 → 스토어 ID (테스트 → 운영 채널로 전환)
+- [ ] `PORTONE_CHANNEL_KEY` — 운영 채널 키 (본인인증 채널)
+- [ ] `PORTONE_API_SECRET` — PortOne V2 API Secret
+- PortOne 콘솔에서 도메인 화이트리스트 등록: `https://retrip.io`, `https://api.retrip.io`
+
+### AWS S3
+- [ ] `AWS_ACCESS_KEY_ID` — 운영용 IAM 사용자 (최소 권한: s3:PutObject, s3:GetObject)
+- [ ] `AWS_SECRET_ACCESS_KEY`
+- 운영 환경 EC2/ECS에서는 IAM Role 사용 권장 (application-prod.yml은 이미 DefaultCredentialsProvider 설정됨)
+
+### 앱 설정
+- [ ] `FRONTEND_CALLBACK_URL` — `https://retrip.io/auth/callback` (운영 도메인으로 변경)
+
+---
+
+## application.yml 현재 설정 확인
+
+`src/main/resources/application.yml` 기준 환경변수 참조 현황:
+
+```yaml
+token.jwt.private-key: ${JWT_PRIVATE_KEY}
+token.jwt.public-key: ${JWT_PUBLIC_KEY}
+spring.security.oauth2.client.registration.google.client-id: ${GOOGLE_CLIENT_ID:your-google-client-id}
+spring.security.oauth2.client.registration.google.client-secret: ${GOOGLE_CLIENT_SECRET:your-google-client-secret}
+spring.security.oauth2.client.registration.kakao.client-id: ${KAKAO_CLIENT_ID:your-kakao-rest-api-key}
+spring.security.oauth2.client.registration.kakao.client-secret: ${KAKAO_CLIENT_SECRET:your-kakao-client-secret}
+spring.security.oauth2.client.registration.naver.client-id: ${NAVER_CLIENT_ID:your-naver-client-id}
+spring.security.oauth2.client.registration.naver.client-secret: ${NAVER_CLIENT_SECRET:your-naver-client-secret}
+portone.public.store-id: ${PORTONE_STORE_ID}
+portone.public.channel-key: ${PORTONE_CHANNEL_KEY}
+portone.api_secret: ${PORTONE_API_SECRET}
+cloud.aws.credentials.access-key: ${AWS_ACCESS_KEY_ID}
+cloud.aws.credentials.secret-key: ${AWS_SECRET_ACCESS_KEY}
+app.frontend-callback-url: ${FRONTEND_CALLBACK_URL:http://localhost:3000/auth/callback}
+```
+
+redirect-uri가 `localhost:8080` 하드코딩되어 있음 — **운영 도메인으로 변경 필요**:
+```yaml
+# 변경 전
+redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+# 변경 후 (환경변수화 권장)
+redirect-uri: "${APP_BASE_URL:http://localhost:8080}/login/oauth2/code/google"
+```
+
+---
+
+## 운영 배포 시 추가 확인 사항
+
+### DB 전환
+- 로컬: H2 in-memory → 운영: MySQL
+- `application-prod.yml` 에 MySQL datasource 설정 확인
+- `ddl-auto: update` → 운영에서는 `validate` 또는 Flyway/Liquibase 전환 권장
+- **member_social_provider 테이블 수동 생성 필요** (신규 테이블, 이번 PR에서 추가됨)
+- **member 테이블에서 provider_id 컬럼 제거, nickname 컬럼 추가** (마이그레이션 스크립트 필요)
+
+### Docker / CI-CD
+- 환경변수를 GitHub Secrets 또는 서버 `.env`에 등록
+- `spring.profiles.active=prod` 설정 확인
+- application-prod.yml S3 설정: IAM Role 기반이므로 `AWS_ACCESS_KEY_ID` 불필요
+
+### 반드시 삭제할 파일
+- `src/main/java/com/retrip/auth/infra/adapter/in/rest/in/DebugController.java`
+  → `/debug/tokens` 엔드포인트가 인증 없이 전체 리프레시 토큰 노출, **운영 배포 전 필수 삭제**
+
+---
+
+## 소셜 로그인 운영 전환 플로우 검증 시나리오
+
+1. 카카오 운영 앱으로 로그인 → JWT 정상 발급 확인
+2. 네이버 운영 앱으로 로그인 → 동일 이메일 카카오 계정과 자동 연동 확인
+3. PortOne 운영 채널로 본인인증 → isVerified=true, name/birthDate 업데이트 확인
+4. 소셜 로그인 후 콜백 URL → `https://retrip.io/auth/callback?accessToken=...` 정상 리다이렉트
+5. RefreshToken Cookie 운영 도메인 (secure, httpOnly, sameSite=None) 설정 확인

--- a/.claude/memory-bootstrap/project_retrip_overview.md
+++ b/.claude/memory-bootstrap/project_retrip_overview.md
@@ -1,0 +1,72 @@
+---
+name: Retrip 프로젝트 전체 개요
+description: Retrip 팀 프로젝트 도메인 구조, 기술 스택, 팀 구성
+type: project
+---
+
+## 프로젝트 개요
+
+**Retrip** — 여행 메이트 매칭 앱. 함께 여행할 사람을 찾고 여행을 계획하는 서비스.
+
+## 도메인 구성
+
+| 도메인 | 담당 | 설명 |
+|--------|------|------|
+| **auth** | 이 개발자 | 회원가입, 로그인, 소셜 로그인, 본인인증, 프로필 |
+| **trip** | 다른 팀원(민수민님 외) | 여행 생성, 초대, 신청, 매칭 |
+
+- auth와 trip은 **별도 Spring Boot 서비스**로 분리
+- trip 도메인은 auth의 JWT를 검증하고 `UserContext.nickName` 등 JWT claims 사용
+- 회원 검색/배치조회는 auth가 API 제공 → trip이 소비
+
+## 기술 스택 (auth 기준)
+
+- **언어/프레임워크**: Java, Spring Boot
+- **아키텍처**: 헥사고날 (Ports & Adapters)
+- **보안**: Spring Security, JWT RS256
+- **DB**: H2 (로컬/테스트), MySQL (운영)
+- **ORM**: JPA/Hibernate (ddl-auto: update)
+- **소셜 로그인**: Kakao, Naver, Google (Spring OAuth2 Client)
+- **본인인증**: PortOne V2 (실명인증)
+- **이미지 스토리지**: AWS S3 (Presigned URL 방식)
+- **API 문서**: Springdoc (Swagger UI)
+- **배포**: Docker, GitHub Actions CI/CD
+
+## 패키지 구조 (헥사고날)
+
+```
+com.retrip.auth
+├── application
+│   ├── config/          ← Spring Security, JWT, OAuth2 설정
+│   ├── dto/             ← 내부 DTO (request/response)
+│   ├── in/              ← Inbound port (UseCase 구현, OAuth2 서비스)
+│   │   ├── request/     ← API 요청 DTO
+│   │   ├── response/    ← API 응답 DTO
+│   │   └── usercase/    ← UseCase 인터페이스
+│   ├── out/repository/  ← Outbound port (Repository 인터페이스)
+│   └── service/         ← ProfileService 등 부가 서비스
+├── domain
+│   ├── entity/          ← JPA 엔티티 (Member, MemberSocialProvider 등)
+│   └── exception/       ← 도메인 예외, ErrorCode
+└── infra
+    └── adapter/in/rest/ ← Controller, Filter, Handler
+```
+
+## Git 브랜치 전략
+
+- `main` — 운영 배포
+- `develop` — 통합 개발 브랜치 (PR 기준)
+- `feat/*` — 기능 브랜치
+
+현재 auth 구현 PR: `feat/social-login-multi-provider-nickname` → develop
+
+## 팀원 커밋 현황 (2026-04-02 기준)
+
+팀원이 develop에 병합한 기능:
+- `GET /users/members?ids=` — UUID 목록으로 회원 배치 조회 (trip 도메인 소비)
+- `GET /users/search?name=` — 이름 검색 (초대할 사람 찾기)
+- `POST /images/presigned-url` — S3 Presigned PUT URL 발급 (프로필 이미지 업로드)
+- S3Config: local(StaticCredentials) / prod(IAM DefaultCredentials) 분리
+
+**Why:** trip 도메인이 여행 초대 기능에서 auth 회원 정보 조회가 필요해서 추가됨.
+**How to apply:** 이 API들은 auth 보안 로직과 독립적. JWT 필터체인은 그대로 사용.

--- a/.claude/memory-bootstrap/user_profile.md
+++ b/.claude/memory-bootstrap/user_profile.md
@@ -1,0 +1,14 @@
+---
+name: 사용자 프로필
+description: Retrip 팀 프로젝트 auth 도메인 담당 개발자
+type: user
+---
+
+- Retrip 팀 프로젝트에서 **auth 도메인** 전담 개발자
+- Spring Boot, Java 기반 백엔드 개발자
+- 헥사고날 아키텍처(Ports & Adapters) 패턴을 이해하고 적용 중
+- JWT, OAuth2, Spring Security 개념 이해 있음
+- 팀원과 협업 중 — 팀원이 같은 auth 레포에서 별도 기능(S3, 배치조회) 커밋함
+- 개인 데스크탑(Windows)과 회사 노트북 2기기 사용 — 세션 인계 필요
+- 업계 표준 기반으로 설계 결정하는 것을 선호
+- 코드보다 정책/설계 결정의 근거를 중요하게 생각함

--- a/.github/workflows/deploy_fortest.yml
+++ b/.github/workflows/deploy_fortest.yml
@@ -94,14 +94,24 @@ jobs:
               -p 8081:8080 \
               -e SPRING_PROFILES_ACTIVE=prod \
               -e SERVER_PORT=8080 \
+              -e APP_BASE_URL="${{ secrets.APP_BASE_URL }}" \
+              -e FRONTEND_CALLBACK_URL="${{ secrets.FRONTEND_CALLBACK_URL }}" \
               -e DB_URL="jdbc:mysql://${{ secrets.DB_HOST }}:${{ secrets.DB_PORT }}/${{ secrets.AUTH_DB_NAME }}" \
               -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \
               -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
               -e JWT_PRIVATE_KEY="${{ secrets.JWT_PRIVATE_KEY }}" \
               -e JWT_PUBLIC_KEY="${{ secrets.JWT_PUBLIC_KEY }}" \
+              -e GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
+              -e GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
+              -e KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \
+              -e KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \
+              -e NAVER_CLIENT_ID="${{ secrets.NAVER_CLIENT_ID }}" \
+              -e NAVER_CLIENT_SECRET="${{ secrets.NAVER_CLIENT_SECRET }}" \
               -e PORTONE_STORE_ID="${{ secrets.PORTONE_STORE_ID }}" \
               -e PORTONE_CHANNEL_KEY="${{ secrets.PORTONE_CHANNEL_KEY }}" \
               -e PORTONE_API_SECRET="${{ secrets.PORTONE_API_SECRET }}" \
+              -e AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" \
+              -e AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
               --restart always \
               "$IMAGE"
 

--- a/api-test-cp.http
+++ b/api-test-cp.http
@@ -1,0 +1,71 @@
+### 전역 변수 설정
+# 로컬 환경이므로 localhost 사용
+@auth_host = http://localhost:8080
+@trip_host = http://localhost:8081
+# 중요: MySQL은 데이터가 남으므로, 중복 에러가 나면 이메일을 변경해서 테스트하세요 (test2, test3...)
+@email = test_local_01@naver.com
+@password = Password1234!
+
+### 1. [Auth] 회원가입 (최초 1회 필수)
+# H2와 달리 한번 성공하면 DB에 남습니다.
+# "Already Exists" 에러가 나면 위 @email 변수를 수정하세요.
+POST {{auth_host}}/users
+Content-Type: application/json
+
+{
+  "email": "{{email}}",
+  "password": "{{password}}",
+  "name": "로컬테스터"
+}
+
+### 2. [Auth] 로그인 및 토큰 발급
+# 회원가입한 정보로 로그인을 시도합니다.
+POST {{auth_host}}/login
+Content-Type: application/json
+
+{
+  "id": "{{email}}",
+  "password": "{{password}}"
+}
+
+> {%
+    // 응답에서 accessToken을 추출하여 전역 변수 'auth_token'에 저장
+    client.global.set("auth_token", response.body.data.accessToken);
+    client.global.set("refresh_token", response.body.data.refreshToken);
+    client.log("✅ Access Token 발급 완료: " + response.body.data.accessToken);
+%}
+
+### 3. [Auth] 토큰 재발급 (Reissue) 테스트
+# Access Token 만료 시 Refresh Token을 이용해 재발급 받는지 확인
+POST {{auth_host}}/auth/reissue
+Content-Type: application/json
+Cookie: refreshToken={{refresh_token}}
+
+> {%
+    client.global.set("auth_token", response.body.data.accessToken);
+    client.global.set("refresh_token", response.body.data.refreshToken);
+    client.log("🔄 Token 재발급 완료: " + response.body.data.accessToken);
+%}
+
+### 4. [Trip] 여행 생성 (Trip 서버가 켜져 있어야 함)
+# 주의: 로컬 8081 포트에 TripApplication도 실행 중이어야 가능합니다.
+POST {{trip_host}}/trips
+Content-Type: application/json
+Authorization: Bearer {{auth_token}}
+
+{
+  "locationId": "550e8400-e29b-41d4-a716-446655440001",
+  "title": "로컬 DB 연결 테스트 여행",
+  "description": "MySQL 연결이 잘 되었는지 확인하는 여행입니다.",
+  "start": "2026-08-01",
+  "end": "2026-08-05",
+  "open": true,
+  "maxParticipants": 4,
+  "category": "DOMESTIC",
+  "hashTags": ["테스트", "MySQL", "로컬"]
+}
+
+### 5. [Trip] 생성된 여행 목록 조회
+GET {{trip_host}}/trips
+Content-Type: application/json
+Authorization: Bearer {{auth_token}}

--- a/api-test.http
+++ b/api-test.http
@@ -14,15 +14,14 @@ Content-Type: application/json
   "name": "테스터"
 }
 
-### 2. DB에 저장된 토큰 조회 (디버깅)
-GET http://localhost:8080/debug/tokens
-
 ### 2. [Auth] 로그인 및 토큰 발급
-# 주의: LoginAuthenticationFilter 구현에 따라 id, password를 헤더로 전송합니다.
 POST {{auth_host}}/login
 Content-Type: application/json
-id: {{email}}
-password: {{password}}
+
+{
+  "id": "{{email}}",
+  "password": "{{password}}"
+}
 
 > {%
     // 응답에서 accessToken을 추출하여 전역 변수 'auth_token'에 저장

--- a/api-test2.http
+++ b/api-test2.http
@@ -6,8 +6,8 @@
 ### 전역 변수 설정 (랜덤 값 사용)
 @random_id = {{$randomInt}}
 @email = test2{{random_id}}@naver.com
-@password = password1234
-@new_password = newpassword5678
+@password = Password1234!
+@new_password = Newpassword5678!
 @auth_host = http://15.164.112.64:8081
 @trip_host = http://15.164.112.64:8080
 
@@ -45,16 +45,6 @@ Content-Type: application/json
     client.log("Access Token: " + response.body.data.accessToken.substring(0, 20) + "...");
 %}
 
-
-### 1-2. [Auth] DB에 Refresh Token 저장 확인 (디버깅용)
-GET {{auth_host}}/debug/tokens
-
-> {%
-    client.test("Refresh Token이 DB에 저장됨", function() {
-        client.assert(response.body.length > 0, "Refresh Token이 DB에 존재해야 함");
-    });
-    client.log("✅ DB에 Refresh Token 저장 확인");
-%}
 
 ### ========================================
 ### 📌 Phase 2: 내 정보 조회 (신규 API)
@@ -357,21 +347,7 @@ Authorization: Bearer {{auth_token}}
     client.log("✅ 회원탈퇴 완료");
 %}
 
-### 9-3. [Auth] DB에서 Refresh Token 삭제 확인
-GET {{auth_host}}/debug/tokens
-
-> {%
-    client.test("Refresh Token 삭제 확인", function() {
-        // 탈퇴한 회원의 토큰이 없어야 함
-        let memberTokenExists = response.body.some(token =>
-            token.memberId === client.global.get("member_id")
-        );
-        client.assert(memberTokenExists === false, "탈퇴한 회원의 Refresh Token이 삭제되어야 함");
-    });
-    client.log("✅ Refresh Token 삭제 확인");
-%}
-
-### 9-4. [Trip] 탈퇴 후 여행 조회 시도 (실패해야 함)
+### 9-3. [Trip] 탈퇴 후 여행 조회 시도 (실패해야 함)
 GET {{trip_host}}/trips/my?tripStatus=RECRUITING
 Authorization: Bearer {{auth_token}}
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html lang="ko">
 <head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,1437 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Retrip Wireframe — Auth & MY</title>
+<style>
+  :root {
+    --primary: #5B67F8;
+    --primary-light: #EEF0FF;
+    --gray100: #F5F5F5;
+    --gray200: #EBEBEB;
+    --gray300: #D0D0D0;
+    --gray400: #ABABAB;
+    --gray600: #6E6E6E;
+    --gray800: #2E2E2E;
+    --black: #111111;
+    --white: #FFFFFF;
+    --red: #F24E4E;
+    --green: #2DCA73;
+    --badge: #F5A623;
+    --radius: 12px;
+    --phone-w: 375px;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #E8E8E8;
+    font-family: -apple-system, 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
+    color: var(--black);
+  }
+
+  /* ── Layout ── */
+  .app-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  /* Top Navigation */
+  .top-nav {
+    background: var(--white);
+    border-bottom: 1px solid var(--gray200);
+    padding: 12px 16px;
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    align-items: center;
+  }
+  .top-nav .logo {
+    font-weight: 800;
+    font-size: 18px;
+    color: var(--primary);
+    margin-right: 12px;
+    letter-spacing: -0.5px;
+  }
+  .group-label {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--gray400);
+    text-transform: uppercase;
+    margin-right: 4px;
+    letter-spacing: 0.5px;
+  }
+  .nav-btn {
+    padding: 6px 12px;
+    border-radius: 20px;
+    border: 1.5px solid var(--gray300);
+    background: var(--white);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--gray600);
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+  .nav-btn:hover { border-color: var(--primary); color: var(--primary); }
+  .nav-btn.active { background: var(--primary); color: white; border-color: var(--primary); }
+  .divider-v { width: 1px; height: 24px; background: var(--gray200); margin: 0 4px; }
+
+  /* Main */
+  main {
+    display: flex;
+    justify-content: center;
+    padding: 32px 16px 60px;
+    gap: 24px;
+    flex-wrap: wrap;
+  }
+
+  /* Phone Frame */
+  .phone {
+    width: var(--phone-w);
+    background: var(--white);
+    border-radius: 36px;
+    box-shadow: 0 8px 40px rgba(0,0,0,0.18);
+    overflow: hidden;
+    flex-shrink: 0;
+    position: relative;
+    border: 8px solid #1A1A1A;
+  }
+  .phone-notch {
+    background: #1A1A1A;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .phone-notch span {
+    width: 80px; height: 18px;
+    background: #000;
+    border-radius: 12px;
+    display: block;
+  }
+  .phone-screen {
+    height: 700px;
+    overflow-y: auto;
+    background: var(--white);
+    position: relative;
+  }
+  .phone-screen::-webkit-scrollbar { width: 4px; }
+  .phone-screen::-webkit-scrollbar-thumb { background: var(--gray300); border-radius: 2px; }
+  .phone-label {
+    text-align: center;
+    margin-top: 12px;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--gray600);
+    letter-spacing: -0.3px;
+  }
+  .phone-sublabel {
+    text-align: center;
+    font-size: 11px;
+    color: var(--gray400);
+    margin-top: 2px;
+  }
+
+  /* ── Annotation ── */
+  .annotation {
+    background: #FFFBEA;
+    border-left: 3px solid #F5A623;
+    padding: 8px 12px;
+    font-size: 11px;
+    color: #7A5C00;
+    margin: 8px 16px;
+    border-radius: 0 6px 6px 0;
+  }
+
+  /* ── Section Header ── */
+  .section-header {
+    background: var(--primary);
+    padding: 32px 24px 20px;
+    width: 100%;
+    text-align: center;
+  }
+  .section-header .logo-text {
+    font-size: 28px; font-weight: 900; color: white; letter-spacing: -1px;
+  }
+  .section-header p { font-size: 13px; color: rgba(255,255,255,0.8); margin-top: 4px; }
+
+  /* ── Component Library ── */
+  /* Status Bar */
+  .status-bar {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 8px 20px 4px;
+    font-size: 11px; font-weight: 700;
+  }
+  .status-bar .time { color: var(--black); }
+  .status-bar .icons { display: flex; gap: 4px; align-items: center; }
+  .status-bar .icons span { font-size: 12px; }
+
+  /* App Bar */
+  .app-bar {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--gray200);
+  }
+  .app-bar .title { font-size: 17px; font-weight: 700; letter-spacing: -0.3px; }
+  .app-bar .back-btn {
+    width: 32px; height: 32px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 18px; color: var(--gray800);
+  }
+  .app-bar .action { font-size: 14px; color: var(--primary); font-weight: 600; }
+
+  /* Button */
+  .btn-primary {
+    width: 100%; padding: 15px;
+    background: var(--primary);
+    color: white; font-size: 16px; font-weight: 700;
+    border: none; border-radius: var(--radius); cursor: pointer;
+    letter-spacing: -0.3px;
+  }
+  .btn-outline {
+    width: 100%; padding: 14px;
+    background: transparent;
+    color: var(--primary); font-size: 15px; font-weight: 600;
+    border: 1.5px solid var(--primary); border-radius: var(--radius);
+  }
+  .btn-gray {
+    width: 100%; padding: 14px;
+    background: var(--gray100);
+    color: var(--gray600); font-size: 15px; font-weight: 600;
+    border: none; border-radius: var(--radius);
+  }
+  .btn-danger {
+    width: 100%; padding: 14px;
+    background: transparent; color: var(--red);
+    font-size: 14px; font-weight: 600;
+    border: 1.5px solid var(--red); border-radius: var(--radius);
+  }
+
+  /* Input */
+  .input-group { margin-bottom: 16px; }
+  .input-label {
+    font-size: 13px; font-weight: 600; color: var(--gray800);
+    margin-bottom: 6px; display: block;
+  }
+  .input-label .req { color: var(--primary); margin-left: 2px; }
+  .input-box {
+    width: 100%; padding: 13px 14px;
+    border: 1.5px solid var(--gray300); border-radius: 10px;
+    font-size: 15px; background: var(--white);
+    color: var(--gray800);
+  }
+  .input-box.filled { border-color: var(--primary); background: var(--primary-light); }
+  .input-box.error { border-color: var(--red); }
+  .input-box.locked {
+    background: var(--gray100); border-color: var(--gray200);
+    color: var(--gray600);
+  }
+  .input-hint {
+    font-size: 11px; color: var(--gray400); margin-top: 4px;
+  }
+  .input-hint.error { color: var(--red); }
+  .input-hint.success { color: var(--green); }
+
+  /* Social Btn */
+  .social-btn {
+    width: 100%; padding: 14px 16px;
+    display: flex; align-items: center; gap: 12px;
+    border-radius: var(--radius); border: 1.5px solid var(--gray200);
+    background: var(--white); font-size: 15px; font-weight: 600;
+    margin-bottom: 10px; cursor: pointer;
+  }
+  .social-icon { width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 14px; font-weight: 900; }
+  .kakao { background: #FEE500; color: #3A1D1D; }
+  .naver { background: #03C75A; color: white; }
+  .google { background: white; border: 1px solid var(--gray200); color: #4285F4; }
+
+  /* Divider */
+  .divider {
+    display: flex; align-items: center; gap: 10px;
+    margin: 16px 0; color: var(--gray400); font-size: 12px;
+  }
+  .divider::before, .divider::after {
+    content: ''; flex: 1; height: 1px; background: var(--gray200);
+  }
+
+  /* Bottom Tabs */
+  .bottom-tabs {
+    display: flex; border-top: 1px solid var(--gray200);
+    background: white; position: sticky; bottom: 0;
+  }
+  .tab-item {
+    flex: 1; padding: 10px 4px 8px;
+    display: flex; flex-direction: column; align-items: center; gap: 4px;
+    font-size: 10px; font-weight: 600; color: var(--gray400);
+  }
+  .tab-item.active { color: var(--primary); }
+  .tab-icon { font-size: 20px; line-height: 1; }
+
+  /* MY Page Components */
+  .profile-header {
+    padding: 24px 20px 20px;
+    background: linear-gradient(160deg, var(--primary) 0%, #7B86FA 100%);
+    display: flex; flex-direction: column; align-items: center; gap: 12px;
+  }
+  .avatar-wrap { position: relative; }
+  .avatar {
+    width: 80px; height: 80px; border-radius: 50%;
+    background: rgba(255,255,255,0.25);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 36px; border: 3px solid rgba(255,255,255,0.5);
+  }
+  .avatar-edit {
+    position: absolute; bottom: 0; right: 0;
+    width: 26px; height: 26px; border-radius: 50%;
+    background: white; display: flex; align-items: center; justify-content: center;
+    font-size: 14px; box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  }
+  .profile-name {
+    font-size: 20px; font-weight: 800; color: white; letter-spacing: -0.5px;
+    display: flex; align-items: center; gap: 6px;
+  }
+  .verified-badge {
+    background: rgba(255,255,255,0.25); border: 1px solid rgba(255,255,255,0.4);
+    border-radius: 20px; padding: 2px 8px;
+    font-size: 11px; font-weight: 700; color: white;
+    display: flex; align-items: center; gap: 4px;
+  }
+  .unverified-badge {
+    background: rgba(255,255,255,0.15); border: 1px solid rgba(255,255,255,0.25);
+    border-radius: 20px; padding: 2px 8px;
+    font-size: 11px; color: rgba(255,255,255,0.7);
+  }
+  .profile-bio { font-size: 13px; color: rgba(255,255,255,0.8); text-align: center; }
+  .style-tags { display: flex; gap: 6px; flex-wrap: wrap; justify-content: center; }
+  .style-tag {
+    background: rgba(255,255,255,0.2); border-radius: 20px;
+    padding: 4px 10px; font-size: 11px; font-weight: 700; color: white;
+  }
+
+  /* Section List */
+  .list-section { padding: 16px 0 0; }
+  .list-section-title {
+    font-size: 12px; font-weight: 700; color: var(--gray400);
+    padding: 0 16px 8px; letter-spacing: 0.3px; text-transform: uppercase;
+  }
+  .list-item {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--gray100);
+  }
+  .list-item:last-child { border-bottom: none; }
+  .list-item-left { display: flex; align-items: center; gap: 12px; }
+  .list-icon {
+    width: 36px; height: 36px; border-radius: 10px;
+    display: flex; align-items: center; justify-content: center; font-size: 18px;
+  }
+  .icon-purple { background: #EEF0FF; }
+  .icon-blue { background: #E8F4FD; }
+  .icon-green { background: #E8FAF0; }
+  .icon-orange { background: #FFF3E0; }
+  .icon-red { background: #FEECEC; }
+  .icon-gray { background: var(--gray100); }
+  .list-item-title { font-size: 15px; font-weight: 600; color: var(--black); }
+  .list-item-sub { font-size: 12px; color: var(--gray400); margin-top: 1px; }
+  .list-chevron { font-size: 14px; color: var(--gray300); }
+  .list-badge {
+    background: var(--red); color: white;
+    font-size: 11px; font-weight: 700;
+    width: 20px; height: 20px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+  }
+
+  /* Toggle */
+  .toggle {
+    width: 48px; height: 28px; border-radius: 14px;
+    position: relative; cursor: pointer; flex-shrink: 0;
+  }
+  .toggle.on { background: var(--primary); }
+  .toggle.off { background: var(--gray300); }
+  .toggle-thumb {
+    width: 22px; height: 22px; border-radius: 50%; background: white;
+    position: absolute; top: 3px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+    transition: left 0.2s;
+  }
+  .toggle.on .toggle-thumb { left: 23px; }
+  .toggle.off .toggle-thumb { left: 3px; }
+
+  /* Chip / Tag */
+  .chip {
+    padding: 6px 12px; border-radius: 20px;
+    font-size: 13px; font-weight: 600;
+    display: inline-flex; align-items: center; gap: 4px;
+  }
+  .chip.selected { background: var(--primary-light); color: var(--primary); border: 1.5px solid var(--primary); }
+  .chip.unselected { background: var(--gray100); color: var(--gray600); border: 1.5px solid var(--gray200); }
+
+  /* Step Indicator */
+  .step-indicator {
+    display: flex; align-items: center; justify-content: center; gap: 6px;
+    padding: 12px 0 0;
+  }
+  .step-dot {
+    width: 8px; height: 8px; border-radius: 50%; background: var(--gray200);
+  }
+  .step-dot.active { background: var(--primary); width: 24px; border-radius: 4px; }
+  .step-dot.done { background: var(--primary); }
+
+  /* Check List (Terms) */
+  .check-item {
+    display: flex; align-items: center; gap: 12px;
+    padding: 14px 0; border-bottom: 1px solid var(--gray100);
+  }
+  .check-circle {
+    width: 24px; height: 24px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+    font-size: 14px;
+  }
+  .check-circle.checked { background: var(--primary); color: white; }
+  .check-circle.unchecked { border: 2px solid var(--gray300); }
+  .check-text { font-size: 14px; color: var(--gray800); flex: 1; }
+  .check-arrow { font-size: 14px; color: var(--gray300); }
+
+  /* History Card */
+  .history-card {
+    border: 1.5px solid var(--gray200); border-radius: var(--radius);
+    padding: 14px; margin-bottom: 10px;
+  }
+  .history-card-header { display: flex; justify-content: space-between; align-items: flex-start; }
+  .history-trip-name { font-size: 15px; font-weight: 700; }
+  .status-pill {
+    font-size: 11px; font-weight: 700; padding: 4px 8px; border-radius: 20px;
+  }
+  .status-pending { background: #FFF3E0; color: #E65100; }
+  .status-accepted { background: #E8FAF0; color: #1B8A4B; }
+  .status-rejected { background: #FEECEC; color: var(--red); }
+  .status-expired { background: var(--gray100); color: var(--gray400); }
+  .history-meta { font-size: 12px; color: var(--gray400); margin-top: 6px; }
+  .history-actions { display: flex; gap: 8px; margin-top: 12px; }
+  .mini-btn {
+    flex: 1; padding: 9px; border-radius: 8px;
+    font-size: 13px; font-weight: 600; text-align: center;
+  }
+  .mini-btn.accept { background: var(--primary); color: white; }
+  .mini-btn.reject { background: var(--gray100); color: var(--gray600); }
+
+  /* Account Provider Tag */
+  .provider-row {
+    display: flex; align-items: center; gap: 10px; padding: 12px 0;
+    border-bottom: 1px solid var(--gray100);
+  }
+  .provider-icon {
+    width: 36px; height: 36px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center; font-size: 16px;
+    font-weight: 900; flex-shrink: 0;
+  }
+  .p-email { background: var(--gray100); color: var(--gray600); }
+  .p-kakao { background: #FEE500; color: #3A1D1D; }
+  .p-naver { background: #03C75A; color: white; }
+  .p-google { background: white; border: 1px solid var(--gray200); }
+  .provider-info { flex: 1; }
+  .provider-name { font-size: 14px; font-weight: 600; }
+  .provider-email { font-size: 12px; color: var(--gray400); margin-top: 1px; }
+  .provider-current {
+    font-size: 11px; font-weight: 700; color: var(--primary);
+    background: var(--primary-light); padding: 3px 8px; border-radius: 10px;
+  }
+
+  /* ─── Screen-specific ─── */
+  .p16 { padding: 16px; }
+  .p20 { padding: 20px; }
+  .mt8 { margin-top: 8px; }
+  .mt12 { margin-top: 12px; }
+  .mt16 { margin-top: 16px; }
+  .mt20 { margin-top: 20px; }
+  .mt24 { margin-top: 24px; }
+  .text-center { text-align: center; }
+  .text-gray { color: var(--gray400); font-size: 13px; }
+  .text-small { font-size: 12px; }
+  .bold { font-weight: 700; }
+  .link-text { color: var(--primary); font-size: 13px; font-weight: 600; text-decoration: underline; }
+
+  /* PRD Notes */
+  .prd-note {
+    background: #F0F4FF; border-radius: 8px; padding: 10px 12px;
+    font-size: 11px; color: #3D5A99; margin: 8px 16px;
+    border-left: 3px solid var(--primary);
+    line-height: 1.6;
+  }
+
+  /* Page sections */
+  .page-section {
+    background: var(--white);
+    padding: 24px 20px 12px;
+    border-bottom: 8px solid var(--gray100);
+    text-align: center;
+  }
+  .page-section h2 {
+    font-size: 22px; font-weight: 900; color: var(--gray800);
+    letter-spacing: -0.5px;
+  }
+  .page-section p { font-size: 13px; color: var(--gray400); margin-top: 6px; }
+
+  /* Screen hidden/visible */
+  .screen { display: none; }
+  .screen.visible { display: block; }
+
+  /* Password policy */
+  .pw-rule { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--gray400); margin-top: 4px; }
+  .pw-rule .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--gray300); flex-shrink: 0; }
+  .pw-rule.pass { color: var(--green); }
+  .pw-rule.pass .dot { background: var(--green); }
+
+  /* Verify CTA */
+  .verify-cta {
+    background: linear-gradient(135deg, #667EEA 0%, #764BA2 100%);
+    border-radius: 14px; padding: 20px;
+    display: flex; flex-direction: column; gap: 10px; margin: 0 16px;
+  }
+  .verify-cta h3 { font-size: 16px; font-weight: 800; color: white; }
+  .verify-cta p { font-size: 12px; color: rgba(255,255,255,0.8); line-height: 1.5; }
+
+  /* Separator section */
+  .list-separator { height: 8px; background: var(--gray100); }
+
+  /* Scroll area notice */
+  .scroll-notice {
+    text-align: center; color: var(--gray300); font-size: 11px;
+    padding: 8px; letter-spacing: 0.3px;
+  }
+</style>
+</head>
+<body>
+<div class="app-shell">
+
+<!-- Top Navigation -->
+<nav class="top-nav">
+  <span class="logo">retrip</span>
+  <span class="divider-v"></span>
+  <span class="group-label">인증</span>
+  <button class="nav-btn active" onclick="showGroup('auth')">로그인 홈</button>
+  <button class="nav-btn" onclick="showScreen('signup1')">회원가입</button>
+  <button class="nav-btn" onclick="showScreen('verify-id')">본인인증 유도</button>
+  <span class="divider-v"></span>
+  <span class="group-label">MY 탭</span>
+  <button class="nav-btn" onclick="showScreen('my-unverified')">MY (미인증)</button>
+  <button class="nav-btn" onclick="showScreen('my-verified')">MY (인증완료)</button>
+  <button class="nav-btn" onclick="showScreen('my-profile-edit')">프로필 편집</button>
+  <button class="nav-btn" onclick="showScreen('my-notification')">알림 설정</button>
+  <button class="nav-btn" onclick="showScreen('my-history')">여행 히스토리</button>
+  <button class="nav-btn" onclick="showScreen('my-account')">계정 관리</button>
+  <span class="divider-v"></span>
+  <span class="group-label">흐름</span>
+  <button class="nav-btn" onclick="showGroup('all')">전체 보기</button>
+</nav>
+
+<main id="main-area">
+
+<!-- ═══════════════════════════════════════════
+     AUTH SCREENS
+════════════════════════════════════════════ -->
+
+<!-- S1: 로그인 홈 -->
+<div class="phone screen visible" id="s-login-home">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>●●●</span><span>WiFi</span><span>🔋</span></div></div>
+
+    <!-- 로고 영역 -->
+    <div style="padding: 48px 20px 20px; text-align:center;">
+      <div style="font-size:36px; font-weight:900; color:var(--primary); letter-spacing:-1.5px; line-height:1;">retrip</div>
+      <div style="font-size:13px; color:var(--gray400); margin-top:8px;">나만의 여행, 함께하는 리트립</div>
+    </div>
+
+    <!-- 일러스트 자리 -->
+    <div style="background:var(--primary-light); margin:0 20px; border-radius:16px; height:160px; display:flex;align-items:center;justify-content:center; flex-direction:column; gap:8px;">
+      <div style="font-size:48px;">✈️🚲🌍</div>
+      <div style="font-size:12px; color:var(--primary); font-weight:600;">Hero Illustration</div>
+    </div>
+
+    <div class="p20 mt12">
+      <!-- 소셜 로그인 -->
+      <div class="social-btn"><div class="social-icon kakao">K</div><span>카카오로 시작하기</span></div>
+      <div class="social-btn"><div class="social-icon naver">N</div><span>네이버로 시작하기</span></div>
+      <div class="social-btn"><div class="social-icon google">G</div><span>Google로 시작하기</span></div>
+
+      <div class="divider">또는</div>
+
+      <button class="btn-outline" style="margin-bottom:12px;">이메일로 로그인</button>
+      <button class="btn-gray">이메일로 회원가입</button>
+
+      <div class="text-center mt16">
+        <span class="text-gray">비밀번호를 잊으셨나요? </span>
+        <span class="link-text">찾기</span>
+      </div>
+    </div>
+
+    <div style="height:20px;"></div>
+  </div>
+  <div class="phone-label">로그인 홈</div>
+  <div class="phone-sublabel">소셜 3종 + 이메일</div>
+</div>
+
+<!-- S2: 이메일 로그인 -->
+<div class="phone screen" id="s-login-email">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>●●●</span><span>WiFi</span><span>🔋</span></div></div>
+    <div class="app-bar">
+      <div class="back-btn">←</div>
+      <div class="title">이메일 로그인</div>
+      <div style="width:32px;"></div>
+    </div>
+
+    <div class="p20 mt12">
+      <div class="input-group">
+        <label class="input-label">이메일<span class="req">*</span></label>
+        <div class="input-box filled">user@example.com</div>
+      </div>
+      <div class="input-group">
+        <label class="input-label">비밀번호<span class="req">*</span></label>
+        <div class="input-box filled">••••••••••</div>
+        <div class="input-hint">
+          <span class="link-text" style="font-size:12px;">비밀번호 찾기</span>
+        </div>
+      </div>
+
+      <div class="mt24">
+        <button class="btn-primary">로그인</button>
+      </div>
+
+      <!-- 에러 케이스 예시 -->
+      <div style="background:#FEECEC; border-radius:8px; padding:10px 14px; margin-top:16px; font-size:13px; color:var(--red); display:flex; gap:8px; align-items:center;">
+        <span>⚠️</span><span>이메일 또는 비밀번호가 일치하지 않습니다</span>
+      </div>
+
+      <div class="text-center mt20">
+        <span class="text-gray">계정이 없으신가요? </span>
+        <span class="link-text">회원가입</span>
+      </div>
+    </div>
+  </div>
+  <div class="phone-label">이메일 로그인</div>
+  <div class="phone-sublabel">에러 케이스 포함</div>
+</div>
+
+<!-- S3: 회원가입 Step 1 -->
+<div class="phone screen" id="signup1">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>●●●</span></div></div>
+    <div class="app-bar">
+      <div class="back-btn">←</div>
+      <div class="title">회원가입</div>
+      <div style="width:32px;"></div>
+    </div>
+
+    <div class="step-indicator">
+      <div class="step-dot active"></div>
+      <div class="step-dot"></div>
+      <div class="step-dot"></div>
+    </div>
+    <div style="text-align:center; font-size:12px; color:var(--gray400); margin-top:6px;">1 / 3 — 계정 정보</div>
+
+    <div class="p20 mt8">
+      <div class="input-group">
+        <label class="input-label">이메일<span class="req">*</span></label>
+        <div class="input-box filled">user@example.com</div>
+        <div class="input-hint success">✓ 사용 가능한 이메일입니다</div>
+      </div>
+      <div class="input-group">
+        <label class="input-label">비밀번호<span class="req">*</span></label>
+        <div class="input-box filled">••••••••••</div>
+        <div class="pw-rule pass"><div class="dot"></div>8자 이상</div>
+        <div class="pw-rule pass"><div class="dot"></div>영문 대소문자 포함</div>
+        <div class="pw-rule pass"><div class="dot"></div>숫자 포함</div>
+        <div class="pw-rule pass"><div class="dot"></div>특수문자 포함 (!@#$%^&*)</div>
+      </div>
+      <div class="input-group">
+        <label class="input-label">비밀번호 확인<span class="req">*</span></label>
+        <div class="input-box filled">••••••••••</div>
+        <div class="input-hint success">✓ 비밀번호가 일치합니다</div>
+      </div>
+      <div class="mt12">
+        <button class="btn-primary">다음</button>
+      </div>
+    </div>
+  </div>
+  <div class="phone-label">회원가입 1/3</div>
+  <div class="phone-sublabel">이메일 & 비밀번호</div>
+</div>
+
+<!-- S4: 회원가입 Step 2 -->
+<div class="phone screen" id="signup2">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>●●●</span></div></div>
+    <div class="app-bar">
+      <div class="back-btn">←</div>
+      <div class="title">회원가입</div>
+      <div style="width:32px;"></div>
+    </div>
+    <div class="step-indicator">
+      <div class="step-dot done"></div>
+      <div class="step-dot active"></div>
+      <div class="step-dot"></div>
+    </div>
+    <div style="text-align:center; font-size:12px; color:var(--gray400); margin-top:6px;">2 / 3 — 기본 정보</div>
+
+    <div class="p20 mt8">
+      <div class="input-group">
+        <label class="input-label">이름<span class="req">*</span></label>
+        <div class="input-box filled">홍길동</div>
+        <div class="input-hint">최대 10자 · 본인인증 완료 시 수정 불가</div>
+      </div>
+      <div class="input-group">
+        <label class="input-label">성별<span class="req">*</span></label>
+        <div style="display:flex; gap:10px;">
+          <div style="flex:1; padding:13px; border:1.5px solid var(--primary); border-radius:10px; text-align:center; font-weight:700; color:var(--primary); background:var(--primary-light);">남성</div>
+          <div style="flex:1; padding:13px; border:1.5px solid var(--gray200); border-radius:10px; text-align:center; font-weight:600; color:var(--gray400);">여성</div>
+        </div>
+      </div>
+      <div class="input-group">
+        <label class="input-label">생년월일<span class="req">*</span></label>
+        <div class="input-box filled">1998-03-15</div>
+        <div class="input-hint">YYYY-MM-DD 형식 · 본인인증 완료 시 수정 불가</div>
+      </div>
+      <div class="mt12">
+        <button class="btn-primary">다음</button>
+      </div>
+    </div>
+  </div>
+  <div class="phone-label">회원가입 2/3</div>
+  <div class="phone-sublabel">이름·성별·생년월일</div>
+</div>
+
+<!-- S5: 약관 동의 -->
+<div class="phone screen" id="signup3">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>●●●</span></div></div>
+    <div class="app-bar">
+      <div class="back-btn">←</div>
+      <div class="title">약관 동의</div>
+      <div style="width:32px;"></div>
+    </div>
+    <div class="step-indicator">
+      <div class="step-dot done"></div>
+      <div class="step-dot done"></div>
+      <div class="step-dot active"></div>
+    </div>
+    <div style="text-align:center; font-size:12px; color:var(--gray400); margin-top:6px;">3 / 3 — 약관</div>
+
+    <div class="p20 mt8">
+      <!-- 전체 동의 -->
+      <div style="background:var(--primary-light); border-radius:12px; padding:14px; display:flex; align-items:center; gap:12px; margin-bottom:8px;">
+        <div class="check-circle checked">✓</div>
+        <div style="font-size:15px; font-weight:700; color:var(--primary);">전체 동의</div>
+      </div>
+
+      <div class="check-item">
+        <div class="check-circle checked">✓</div>
+        <div class="check-text">[필수] 서비스 이용약관</div>
+        <div class="check-arrow">›</div>
+      </div>
+      <div class="check-item">
+        <div class="check-circle checked">✓</div>
+        <div class="check-text">[필수] 개인정보 처리방침</div>
+        <div class="check-arrow">›</div>
+      </div>
+      <div class="check-item">
+        <div class="check-circle checked">✓</div>
+        <div class="check-text">[필수] 위치 기반 서비스 이용약관</div>
+        <div class="check-arrow">›</div>
+      </div>
+      <div class="check-item">
+        <div class="check-circle unchecked"></div>
+        <div class="check-text">[선택] 마케팅 수신 동의</div>
+        <div class="check-arrow">›</div>
+      </div>
+
+      <div class="mt20">
+        <button class="btn-primary">가입 완료</button>
+      </div>
+    </div>
+  </div>
+  <div class="phone-label">약관 동의</div>
+  <div class="phone-sublabel">3/3 — 필수/선택 구분</div>
+</div>
+
+<!-- S6: 본인인증 유도 (✅ 회의 확정 — 가입 직후 자동 진입, 건너뛰기 가능) -->
+<div class="phone screen" id="verify-id">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>●●●</span></div></div>
+
+    <!-- 뒤로가기 없음 (가입 완료 후 진입이므로) -->
+    <div style="padding:10px 16px 0;">
+
+      <!-- 가입 완료 진행 흐름 -->
+      <div style="display:flex; align-items:center; gap:4px; padding:6px 0;">
+        <div style="display:flex; align-items:center; gap:3px; font-size:10px; color:var(--gray400);">
+          <div style="width:16px; height:16px; border-radius:50%; background:var(--done); display:flex; align-items:center; justify-content:center; font-size:9px; color:white; font-weight:800;">✓</div>
+          <span>계정</span>
+        </div>
+        <div style="flex:1; height:1.5px; background:var(--done);"></div>
+        <div style="display:flex; align-items:center; gap:3px; font-size:10px; color:var(--gray400);">
+          <div style="width:16px; height:16px; border-radius:50%; background:var(--done); display:flex; align-items:center; justify-content:center; font-size:9px; color:white; font-weight:800;">✓</div>
+          <span>정보</span>
+        </div>
+        <div style="flex:1; height:1.5px; background:var(--done);"></div>
+        <div style="display:flex; align-items:center; gap:3px; font-size:10px; color:var(--gray400);">
+          <div style="width:16px; height:16px; border-radius:50%; background:var(--done); display:flex; align-items:center; justify-content:center; font-size:9px; color:white; font-weight:800;">✓</div>
+          <span>약관</span>
+        </div>
+        <div style="flex:1; height:1.5px; background:var(--primary);"></div>
+        <div style="display:flex; align-items:center; gap:3px; font-size:10px; color:var(--primary); font-weight:700;">
+          <div style="width:16px; height:16px; border-radius:50%; background:var(--primary); display:flex; align-items:center; justify-content:center; font-size:9px; color:white; font-weight:800;">🛡</div>
+          <span style="white-space:nowrap;">인증(선택)</span>
+        </div>
+      </div>
+
+      <!-- 가입 완료 알림 -->
+      <div style="background:var(--done-bg); border-radius:10px; padding:10px 12px; display:flex; align-items:center; gap:8px; margin-top:6px;">
+        <span style="font-size:18px;">🎉</span>
+        <div>
+          <div style="font-size:12px; font-weight:700; color:var(--done);">가입이 완료되었습니다!</div>
+          <div style="font-size:11px; color:var(--gray600);">본인인증을 진행하거나 건너뛸 수 있어요</div>
+        </div>
+      </div>
+    </div>
+
+    <div style="padding:16px 24px 8px; text-align:center;">
+      <div style="font-size:48px; margin-bottom:10px;">🛡️</div>
+      <div style="font-size:20px; font-weight:900; color:var(--black); letter-spacing:-0.5px; line-height:1.3;">
+        신뢰할 수 있는<br/>여행 메이트 되기
+      </div>
+      <div style="font-size:13px; color:var(--gray400); margin-top:10px; line-height:1.7;">
+        본인인증 시 <strong>🛡️ 인증 뱃지</strong>가 부여돼요.<br/>
+        더 많은 여행 메이트에게 신뢰받을 수 있어요!
+      </div>
+    </div>
+
+    <!-- Benefits -->
+    <div style="background:var(--gray100); border-radius:14px; margin:0 20px; padding:14px;">
+      <div style="display:flex; flex-direction:column; gap:10px;">
+        <div style="display:flex; gap:10px; align-items:flex-start; font-size:12px;">
+          <span>✅</span><div><strong>신뢰도 상승</strong> — 인증 뱃지로 안전한 여행 메이트 인증</div>
+        </div>
+        <div style="display:flex; gap:10px; align-items:flex-start; font-size:12px;">
+          <span>✅</span><div><strong>보안 강화</strong> — CI 기반 중복 가입 완전 차단</div>
+        </div>
+        <div style="display:flex; gap:10px; align-items:flex-start; font-size:12px;">
+          <span>✅</span><div><strong>나중에도 가능</strong> — MY 탭에서 언제든 인증 가능</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="p20" style="padding-top:14px;">
+      <button class="btn-primary" style="margin-bottom:10px;">지금 본인인증 하기</button>
+      <!-- 건너뛰기: 클릭 시 여행 홈으로 이동 (isVerified=false 유지) -->
+      <button class="btn-gray">건너뛰기 (나중에 하기)</button>
+      <div style="text-align:center; margin-top:10px; font-size:11px; color:var(--gray400);">
+        포트원(PortOne) 실명 인증 · 건너뛰어도 서비스 이용 가능
+      </div>
+    </div>
+    <div style="height:16px;"></div>
+  </div>
+  <div class="phone-label">본인인증 유도 ✅ 확정</div>
+  <div class="phone-sublabel">가입 직후 자동 진입 · 건너뛰기 가능</div>
+</div>
+
+
+<!-- ═══════════════════════════════════════════
+     MY SCREENS
+════════════════════════════════════════════ -->
+
+<!-- MY: 미인증 -->
+<div class="phone screen" id="my-unverified">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>🔋</span></div></div>
+
+    <div class="profile-header">
+      <div class="avatar-wrap">
+        <div class="avatar">👤</div>
+        <div class="avatar-edit">✏️</div>
+      </div>
+      <div>
+        <div class="profile-name">
+          홍길동
+          <div class="unverified-badge">미인증</div>
+        </div>
+      </div>
+      <div class="profile-bio">사진 찍는 걸 좋아하는 뚜벅이 여행러입니다</div>
+      <div class="style-tags">
+        <div class="style-tag">#계획철저</div>
+        <div class="style-tag">#사진광</div>
+      </div>
+    </div>
+
+    <!-- 인증 CTA -->
+    <div style="padding:12px 16px;">
+      <div class="verify-cta">
+        <div style="display:flex; align-items:center; gap:8px;">
+          <span style="font-size:24px;">🛡️</span>
+          <div>
+            <h3>본인인증으로 신뢰도 올리기</h3>
+            <p>인증 뱃지를 달면 더 많은 여행 메이트를 만날 수 있어요</p>
+          </div>
+        </div>
+        <button style="background:white; color:#764BA2; border:none; border-radius:8px; padding:10px; font-size:13px; font-weight:700; width:100%;">지금 인증하기 →</button>
+      </div>
+    </div>
+
+    <div class="list-separator"></div>
+
+    <!-- 프로필 관리 -->
+    <div class="list-section">
+      <div class="list-section-title">프로필 관리</div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-purple">👤</div>
+          <div><div class="list-item-title">프로필 편집</div><div class="list-item-sub">이름, 소개, 여행 스타일</div></div>
+        </div>
+        <div class="list-chevron">›</div>
+      </div>
+    </div>
+
+    <div class="list-separator"></div>
+
+    <!-- 여행 히스토리 -->
+    <div class="list-section">
+      <div class="list-section-title">여행 히스토리</div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-blue">💌</div>
+          <div><div class="list-item-title">초대함</div><div class="list-item-sub">받은 초대 내역 전체</div></div>
+        </div>
+        <div style="display:flex; align-items:center; gap:8px;"><div class="list-badge">3</div><div class="list-chevron">›</div></div>
+      </div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-green">🙋</div>
+          <div><div class="list-item-title">신청함</div><div class="list-item-sub">내가 신청한 여행 내역</div></div>
+        </div>
+        <div class="list-chevron">›</div>
+      </div>
+    </div>
+
+    <div class="list-separator"></div>
+
+    <!-- 설정 -->
+    <div class="list-section">
+      <div class="list-section-title">설정</div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-orange">🔔</div>
+          <div><div class="list-item-title">알림 설정</div></div>
+        </div>
+        <div style="display:flex; align-items:center; gap:8px;"><div class="toggle on"><div class="toggle-thumb"></div></div><div class="list-chevron">›</div></div>
+      </div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-gray">⚙️</div>
+          <div><div class="list-item-title">계정 관리</div></div>
+        </div>
+        <div class="list-chevron">›</div>
+      </div>
+    </div>
+
+    <div class="list-separator"></div>
+
+    <!-- 기타 -->
+    <div class="list-section">
+      <div class="list-section-title">기타</div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-gray">📄</div>
+          <div><div class="list-item-title">이용약관</div></div>
+        </div>
+        <div class="list-chevron">›</div>
+      </div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-gray">ℹ️</div>
+          <div><div class="list-item-title">버전 정보</div><div class="list-item-sub">v1.0.0</div></div>
+        </div>
+      </div>
+    </div>
+
+    <div style="height:8px;"></div>
+    <div class="bottom-tabs">
+      <div class="tab-item"><div class="tab-icon">✈️</div>여행</div>
+      <div class="tab-item"><div class="tab-icon">🚲</div>나의 여정</div>
+      <div class="tab-item active"><div class="tab-icon">🕵🏻‍♀️</div>MY</div>
+    </div>
+  </div>
+  <div class="phone-label">MY 탭 (미인증)</div>
+  <div class="phone-sublabel">본인인증 CTA 노출</div>
+</div>
+
+<!-- MY: 인증 완료 -->
+<div class="phone screen" id="my-verified">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>🔋</span></div></div>
+
+    <div class="profile-header">
+      <div class="avatar-wrap">
+        <div class="avatar" style="background:rgba(255,255,255,0.3); font-size:0; overflow:hidden;">
+          <div style="width:100%;height:100%;background:linear-gradient(135deg,#a8edea,#fed6e3);"></div>
+        </div>
+        <div class="avatar-edit">✏️</div>
+      </div>
+      <div>
+        <div class="profile-name">
+          홍길동
+          <div class="verified-badge">🛡️ 인증완료</div>
+        </div>
+      </div>
+      <div class="profile-bio">사진 찍는 걸 좋아하는 뚜벅이 여행러입니다</div>
+      <div class="style-tags">
+        <div class="style-tag">#계획철저</div>
+        <div class="style-tag">#사진광</div>
+        <div class="style-tag">#혼여행가능</div>
+      </div>
+    </div>
+
+    <!-- 프로필 관리 -->
+    <div class="list-section">
+      <div class="list-section-title">프로필 관리</div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-purple">👤</div>
+          <div><div class="list-item-title">프로필 편집</div><div class="list-item-sub">소개, MBTI, 여행 스타일</div></div>
+        </div>
+        <div class="list-chevron">›</div>
+      </div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-purple" style="background:#F0FFF4;">🛡️</div>
+          <div><div class="list-item-title">신원 확인</div><div class="list-item-sub" style="color:var(--green);">인증 완료 · 2024.03.15</div></div>
+        </div>
+        <div style="font-size:12px; color:var(--green); font-weight:600;">완료</div>
+      </div>
+    </div>
+
+    <div class="list-separator"></div>
+
+    <!-- 여행 히스토리 -->
+    <div class="list-section">
+      <div class="list-section-title">여행 히스토리</div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-blue">💌</div>
+          <div><div class="list-item-title">초대함</div><div class="list-item-sub">받은 초대 내역 전체</div></div>
+        </div>
+        <div style="display:flex; align-items:center; gap:8px;"><div class="list-badge">2</div><div class="list-chevron">›</div></div>
+      </div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-green">🙋</div>
+          <div><div class="list-item-title">신청함</div><div class="list-item-sub">내가 신청한 여행 내역</div></div>
+        </div>
+        <div class="list-chevron">›</div>
+      </div>
+    </div>
+
+    <div class="list-separator"></div>
+
+    <!-- 설정 -->
+    <div class="list-section">
+      <div class="list-section-title">설정</div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-orange">🔔</div>
+          <div><div class="list-item-title">알림 설정</div></div>
+        </div>
+        <div style="display:flex; align-items:center; gap:8px;"><div class="toggle on"><div class="toggle-thumb"></div></div><div class="list-chevron">›</div></div>
+      </div>
+      <div class="list-item">
+        <div class="list-item-left">
+          <div class="list-icon icon-gray">⚙️</div>
+          <div><div class="list-item-title">계정 관리</div></div>
+        </div>
+        <div class="list-chevron">›</div>
+      </div>
+    </div>
+
+    <div class="list-separator"></div>
+
+    <div class="list-section">
+      <div class="list-section-title">기타</div>
+      <div class="list-item">
+        <div class="list-item-left"><div class="list-icon icon-gray">📄</div><div class="list-item-title">이용약관</div></div>
+        <div class="list-chevron">›</div>
+      </div>
+      <div class="list-item">
+        <div class="list-item-left"><div class="list-icon icon-gray">ℹ️</div><div><div class="list-item-title">버전 정보</div><div class="list-item-sub">v1.0.0</div></div></div>
+      </div>
+    </div>
+    <div style="height:8px;"></div>
+    <div class="bottom-tabs">
+      <div class="tab-item"><div class="tab-icon">✈️</div>여행</div>
+      <div class="tab-item"><div class="tab-icon">🚲</div>나의 여정</div>
+      <div class="tab-item active"><div class="tab-icon">🕵🏻‍♀️</div>MY</div>
+    </div>
+  </div>
+  <div class="phone-label">MY 탭 (인증완료)</div>
+  <div class="phone-sublabel">🛡️ 뱃지 + 잠금 표시</div>
+</div>
+
+<!-- MY: 프로필 편집 -->
+<div class="phone screen" id="my-profile-edit">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>🔋</span></div></div>
+    <div class="app-bar">
+      <div class="back-btn">←</div>
+      <div class="title">프로필 편집</div>
+      <div class="action">저장</div>
+    </div>
+
+    <div style="padding:24px 20px 0; text-align:center;">
+      <div class="avatar-wrap" style="display:inline-block;">
+        <div class="avatar" style="width:90px;height:90px;font-size:40px;background:var(--primary-light);">👤</div>
+        <div class="avatar-edit">📷</div>
+      </div>
+      <div style="font-size:12px; color:var(--gray400); margin-top:8px;">1:1 비율로 크롭됩니다</div>
+    </div>
+
+    <div class="p20">
+      <!-- 이름 (잠금) -->
+      <div class="input-group">
+        <label class="input-label">
+          이름
+          <span style="background:var(--green);color:white;font-size:10px;padding:2px 6px;border-radius:10px;margin-left:6px;font-weight:700;">🛡️ 인증완료</span>
+        </label>
+        <div class="input-box locked">홍길동 🔒</div>
+        <div class="input-hint">본인인증 완료 후 수정이 제한됩니다</div>
+      </div>
+
+      <!-- Bio -->
+      <div class="input-group">
+        <label class="input-label">한 줄 소개<span style="color:var(--gray400); font-weight:400; font-size:12px; margin-left:4px;">0/30자</span></label>
+        <div class="input-box filled">사진 찍는 걸 좋아하는 뚜벅이 여행러입니다</div>
+      </div>
+
+      <!-- MBTI -->
+      <div class="input-group">
+        <label class="input-label">MBTI</label>
+        <div class="input-box filled" style="display:flex; justify-content:space-between; align-items:center;">
+          <span>INFP</span><span style="color:var(--gray400);">▼</span>
+        </div>
+        <div class="input-hint">16가지 유형 또는 비공개 선택 가능</div>
+      </div>
+
+      <!-- 여행 스타일 -->
+      <div class="input-group">
+        <label class="input-label">여행 스타일 <span style="color:var(--gray400);font-size:12px;font-weight:400;">최대 3개</span></label>
+        <div style="display:flex; flex-wrap:wrap; gap:8px; margin-top:8px;">
+          <div class="chip selected">✓ 계획철저</div>
+          <div class="chip selected">✓ 사진광</div>
+          <div class="chip unselected">즉흥적</div>
+          <div class="chip unselected">맛집탐방</div>
+          <div class="chip selected">✓ 혼여행가능</div>
+          <div class="chip unselected">쇼핑러버</div>
+          <div class="chip unselected">힐링추구</div>
+          <div class="chip unselected">액티비티</div>
+        </div>
+      </div>
+
+      <!-- 생년월일 (잠금) -->
+      <div class="input-group">
+        <label class="input-label">생년월일
+          <span style="background:var(--green);color:white;font-size:10px;padding:2px 6px;border-radius:10px;margin-left:6px;font-weight:700;">🛡️ 인증완료</span>
+        </label>
+        <div class="input-box locked">1998-03-15 🔒</div>
+      </div>
+    </div>
+  </div>
+  <div class="phone-label">프로필 편집</div>
+  <div class="phone-sublabel">인증 완료 시 이름/생년월일 잠금</div>
+</div>
+
+<!-- MY: 알림 설정 -->
+<div class="phone screen" id="my-notification">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>🔋</span></div></div>
+    <div class="app-bar">
+      <div class="back-btn">←</div>
+      <div class="title">알림 설정</div>
+      <div style="width:32px;"></div>
+    </div>
+
+    <div class="p16" style="padding-top:20px;">
+      <!-- 마스터 토글 -->
+      <div style="background:var(--primary-light); border-radius:14px; padding:16px; display:flex; align-items:center; justify-content:space-between; margin-bottom:16px;">
+        <div>
+          <div style="font-size:16px; font-weight:700; color:var(--primary);">전체 알림</div>
+          <div style="font-size:12px; color:var(--primary); opacity:0.7; margin-top:2px;">모든 알림을 한 번에 켜고 끌 수 있어요</div>
+        </div>
+        <div class="toggle on"><div class="toggle-thumb"></div></div>
+      </div>
+
+      <!-- PRD 결정: 마스터 토글만 구현 -->
+      <div class="annotation">
+        📌 2차 테스트 범위: 마스터 토글(전체 ON/OFF)만 구현<br/>
+        세부 토글(여행/초대/신청)은 추후 업데이트 예정
+      </div>
+
+      <div style="background:var(--gray100); border-radius:12px; padding:16px; margin-top:12px;">
+        <div style="font-size:14px; font-weight:700; color:var(--gray600); margin-bottom:10px;">알림 유형 (다음 버전)</div>
+        <div style="opacity:0.4;">
+          <div style="display:flex; align-items:center; justify-content:space-between; padding:10px 0; border-bottom:1px solid var(--gray200);">
+            <div style="display:flex; align-items:center; gap:10px;"><span>✈️</span><span style="font-size:14px;">여행 알림</span></div>
+            <div class="toggle on" style="opacity:0.5;"><div class="toggle-thumb"></div></div>
+          </div>
+          <div style="display:flex; align-items:center; justify-content:space-between; padding:10px 0; border-bottom:1px solid var(--gray200);">
+            <div style="display:flex; align-items:center; gap:10px;"><span>💌</span><span style="font-size:14px;">초대 알림</span></div>
+            <div class="toggle on" style="opacity:0.5;"><div class="toggle-thumb"></div></div>
+          </div>
+          <div style="display:flex; align-items:center; justify-content:space-between; padding:10px 0;">
+            <div style="display:flex; align-items:center; gap:10px;"><span>🙋</span><span style="font-size:14px;">신청 알림</span></div>
+            <div class="toggle on" style="opacity:0.5;"><div class="toggle-thumb"></div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="phone-label">알림 설정</div>
+  <div class="phone-sublabel">마스터 토글만 구현</div>
+</div>
+
+<!-- MY: 여행 히스토리 -->
+<div class="phone screen" id="my-history">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>🔋</span></div></div>
+    <div class="app-bar">
+      <div class="back-btn">←</div>
+      <div class="title">여행 히스토리</div>
+      <div style="width:32px;"></div>
+    </div>
+
+    <!-- 탭 -->
+    <div style="display:flex; border-bottom:2px solid var(--gray200);">
+      <div style="flex:1; padding:12px; text-align:center; font-size:14px; font-weight:700; color:var(--primary); border-bottom:2px solid var(--primary); margin-bottom:-2px;">💌 초대함 <span style="background:var(--red);color:white;border-radius:10px;font-size:11px;padding:1px 6px;">3</span></div>
+      <div style="flex:1; padding:12px; text-align:center; font-size:14px; font-weight:600; color:var(--gray400);">🙋 신청함</div>
+    </div>
+
+    <div class="p16" style="padding-top:16px;">
+      <!-- 대기중 -->
+      <div class="history-card">
+        <div class="history-card-header">
+          <div class="history-trip-name">제주 한달살기 🌊</div>
+          <div class="status-pill status-pending">대기중</div>
+        </div>
+        <div class="history-meta">📅 2026.04.10 ~ 04.20 · 방장: 김여행</div>
+        <div class="history-meta" style="margin-top:4px; color:var(--red);">⏰ 응답 기한: 2026.03.25</div>
+        <div class="history-actions">
+          <div class="mini-btn accept">수락</div>
+          <div class="mini-btn reject">거절</div>
+        </div>
+      </div>
+
+      <!-- 수락됨 -->
+      <div class="history-card">
+        <div class="history-card-header">
+          <div class="history-trip-name">도쿄 벚꽃 여행 🌸</div>
+          <div class="status-pill status-accepted">수락</div>
+        </div>
+        <div class="history-meta">📅 2026.03.28 ~ 04.02 · 방장: 이탐험</div>
+      </div>
+
+      <!-- 만료됨 -->
+      <div class="history-card">
+        <div class="history-card-header">
+          <div class="history-trip-name">방콕 맛집 투어 🍜</div>
+          <div class="status-pill status-expired">만료</div>
+        </div>
+        <div class="history-meta">📅 2026.02.15 ~ 02.20 · 방장: 박여정</div>
+      </div>
+    </div>
+  </div>
+  <div class="phone-label">여행 히스토리 (초대함)</div>
+  <div class="phone-sublabel">상태별 카드 UI</div>
+</div>
+
+<!-- MY: 계정 관리 -->
+<div class="phone screen" id="my-account">
+  <div class="phone-notch"><span></span></div>
+  <div class="phone-screen">
+    <div class="status-bar"><span class="time">9:41</span><div class="icons"><span>🔋</span></div></div>
+    <div class="app-bar">
+      <div class="back-btn">←</div>
+      <div class="title">계정 관리</div>
+      <div style="width:32px;"></div>
+    </div>
+
+    <div class="p16" style="padding-top:16px;">
+
+      <!-- 연동 계정 -->
+      <div style="font-size:12px; font-weight:700; color:var(--gray400); margin-bottom:8px; letter-spacing:0.3px;">연동된 계정</div>
+      <div style="background:var(--white); border:1.5px solid var(--gray200); border-radius:12px; padding:0 14px;">
+        <div class="provider-row">
+          <div class="provider-icon p-email">✉️</div>
+          <div class="provider-info">
+            <div class="provider-name">이메일</div>
+            <div class="provider-email">user@example.com</div>
+          </div>
+          <div class="provider-current">현재</div>
+        </div>
+      </div>
+
+      <div class="annotation" style="margin: 10px 0;">
+        소셜 로그인 가입 시: 해당 소셜 아이콘이 "현재"로 표시되며, 비밀번호 변경 메뉴는 숨김 처리됩니다<br/>
+        분기 기준: GET /users/me 의 <code>hasPassword</code> 필드 (<code>false</code> = 소셜 전용 → 비밀번호 변경 메뉴 숨김)
+      </div>
+
+      <!-- 소셜 예시 (참고용) -->
+      <div style="background:var(--gray100); border-radius:12px; padding:0 14px; margin-bottom:16px; opacity:0.5;">
+        <div style="font-size:11px; color:var(--gray400); padding:8px 0; text-align:center;">소셜 로그인 가입 시 예시</div>
+        <div class="provider-row">
+          <div class="provider-icon p-kakao">K</div>
+          <div class="provider-info">
+            <div class="provider-name">카카오</div>
+            <div class="provider-email">kakao_user@kakao.com</div>
+          </div>
+          <div class="provider-current">현재</div>
+        </div>
+      </div>
+
+      <!-- 비밀번호 변경 -->
+      <div style="font-size:12px; font-weight:700; color:var(--gray400); margin-bottom:8px; margin-top:8px; letter-spacing:0.3px;">보안</div>
+      <div style="background:white; border:1.5px solid var(--gray200); border-radius:12px;">
+        <div class="list-item">
+          <div class="list-item-left">
+            <div class="list-icon icon-blue">🔑</div>
+            <div>
+              <div class="list-item-title">비밀번호 변경</div>
+              <div class="list-item-sub">변경 시 전 기기 로그아웃</div>
+            </div>
+          </div>
+          <div class="list-chevron">›</div>
+        </div>
+      </div>
+
+      <!-- 계정 액션 -->
+      <div style="font-size:12px; font-weight:700; color:var(--gray400); margin-bottom:8px; margin-top:16px; letter-spacing:0.3px;">계정</div>
+      <div style="background:white; border:1.5px solid var(--gray200); border-radius:12px;">
+        <div class="list-item">
+          <div class="list-item-left">
+            <div class="list-icon icon-gray">🚪</div>
+            <div><div class="list-item-title">로그아웃</div></div>
+          </div>
+          <div class="list-chevron">›</div>
+        </div>
+        <div class="list-item">
+          <div class="list-item-left">
+            <div class="list-icon icon-red">⚠️</div>
+            <div>
+              <div class="list-item-title" style="color:var(--red);">회원 탈퇴</div>
+              <div class="list-item-sub">모든 데이터가 파기됩니다</div>
+            </div>
+          </div>
+          <div class="list-chevron" style="color:var(--red);">›</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+  <div class="phone-label">계정 관리</div>
+  <div class="phone-sublabel">연동계정 · 보안 · 탈퇴</div>
+</div>
+
+</main>
+</div>
+
+<!-- PRD Summary Panel -->
+<div style="background:white; border-top: 3px solid var(--primary); padding:24px 32px;">
+  <h2 style="font-size:18px;font-weight:900;color:var(--primary);margin-bottom:16px;">📋 PRD 리뷰 & 업계 표준 반영 결과</h2>
+  <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(300px,1fr)); gap:16px;">
+
+    <div style="background:#F8F9FF; border-radius:12px; padding:16px; border-left:4px solid var(--primary);">
+      <div style="font-weight:800; font-size:14px; color:var(--primary); margin-bottom:8px;">✅ 결정 사항</div>
+      <div style="font-size:13px; line-height:1.8; color:#333;">
+        1. 알림: <strong>마스터 ON/OFF만</strong> 구현 (세부 토글 다음 배포)<br/>
+        2. 인증 잠금: 이름·생년월일 <strong>isVerified 체크</strong><br/>
+        3. 소셜 비밀번호: <strong>API 차단 + UI 숨김</strong><br/>
+        4. 탈퇴: <strong>Soft Delete 유지</strong><br/>
+        5. 비밀번호 정책: <strong>업계 표준 적용</strong><br/>
+        6. MBTI 검증: <strong>다음 배포</strong>
+      </div>
+    </div>
+
+    <div style="background:#FFF8F0; border-radius:12px; padding:16px; border-left:4px solid #F5A623;">
+      <div style="font-weight:800; font-size:14px; color:#C17A00; margin-bottom:8px;">🔐 비밀번호 정책 (업계 표준)</div>
+      <div style="font-size:13px; line-height:1.8; color:#333;">
+        • 최소 <strong>8자 ~ 최대 20자</strong><br/>
+        • 영문 대소문자 / 숫자 / 특수문자 중 <strong>3가지 이상</strong><br/>
+        • 허용 특수문자: <code>!@#$%^&*()-_=+[]{}|;:,./</code><br/>
+        • <code>@Pattern</code> 정규식: <code>^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,20}$</code><br/>
+        • 참고: 카카오/네이버 기준
+      </div>
+    </div>
+
+    <div style="background:#F0FFF8; border-radius:12px; padding:16px; border-left:4px solid #2DCA73;">
+      <div style="font-weight:800; font-size:14px; color:#1B8A4B; margin-bottom:8px;">🌐 소셜 로그인 비밀번호 (업계 표준)</div>
+      <div style="font-size:13px; line-height:1.8; color:#333;">
+        소셜 가입 유저는 소셜 플랫폼에서 비밀번호 관리<br/>
+        → 앱 내 비밀번호 없음 (null) → <code>hasPassword() == false</code><br/>
+        → <strong>API에서 <code>hasPassword() == false</code> 시 403 반환 ✅ 구현완료</strong><br/>
+        → <strong>프론트에 <code>hasPassword</code> 필드 전달 → UI 숨김</strong><br/>
+        참고: 카카오톡, 네이버, 토스 동일 정책
+      </div>
+    </div>
+
+    <div style="background:#FFF0F0; border-radius:12px; padding:16px; border-left:4px solid var(--red);">
+      <div style="font-weight:800; font-size:14px; color:var(--red); margin-bottom:8px;">⚠️ 회원탈퇴 PRD 보완 제안</div>
+      <div style="font-size:13px; line-height:1.8; color:#333;">
+        현 PRD: "모든 개인정보 즉시 파기"<br/>
+        현 코드: Soft Delete만 (isDeleted=true)<br/>
+        → <strong>법적 요구사항 충족 위해:</strong><br/>
+        소셜 유저: CI/DI null 처리<br/>
+        이메일 유저: 재가입 불가 체크용 해시만 보존<br/>
+        개인식별정보(이름, 이메일원문)는 마스킹 권장
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+function showScreen(id) {
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('visible'));
+  document.querySelectorAll('.nav-btn').forEach(b => b.classList.remove('active'));
+  const target = document.getElementById('s-' + id) || document.getElementById(id);
+  if (target) target.classList.add('visible');
+  event.target.classList.add('active');
+}
+
+function showGroup(group) {
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('visible'));
+  document.querySelectorAll('.nav-btn').forEach(b => b.classList.remove('active'));
+  event.target.classList.add('active');
+
+  if (group === 'auth') {
+    ['s-login-home','s-login-email','signup1','signup2','signup3','verify-id'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.classList.add('visible');
+    });
+  } else if (group === 'all') {
+    document.querySelectorAll('.screen').forEach(s => s.classList.add('visible'));
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/spec.html
+++ b/docs/spec.html
@@ -1,0 +1,1287 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+<title>Retrip Auth — API & 화면 상태 명세서</title>
+<style>
+:root {
+  --primary:#5B67F8; --primary-light:#EEF0FF;
+  --done:#2DCA73;    --done-bg:#E8FAF0;
+  --todo:#F5A623;    --todo-bg:#FFF8EC;
+  --front:#9B59B6;   --front-bg:#F5EEFF;
+  --del:#F24E4E;     --del-bg:#FEECEC;
+  --gray50:#FAFAFA;  --gray100:#F5F5F5; --gray200:#EBEBEB;
+  --gray400:#ABABAB; --gray600:#6E6E6E; --gray800:#2E2E2E;
+  --black:#111; --white:#FFF;
+  --radius:10px;
+  --font:-apple-system,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;
+}
+*{box-sizing:border-box;margin:0;padding:0;}
+html{scroll-behavior:smooth;}
+body{font-family:var(--font);background:var(--gray50);color:var(--black);line-height:1.6;}
+
+/* ── Layout ── */
+.layout{display:flex;min-height:100vh;}
+.sidebar{
+  width:260px;flex-shrink:0;background:var(--white);
+  border-right:1px solid var(--gray200);
+  position:sticky;top:0;height:100vh;overflow-y:auto;
+  padding:24px 0;
+}
+.sidebar::-webkit-scrollbar{width:4px;}
+.sidebar::-webkit-scrollbar-thumb{background:var(--gray200);border-radius:2px;}
+.content{flex:1;padding:40px 48px;max-width:1100px;}
+@media(max-width:900px){
+  .layout{flex-direction:column;}
+  .sidebar{width:100%;height:auto;position:static;}
+  .content{padding:24px 16px;}
+}
+
+/* ── Sidebar ── */
+.sb-logo{padding:0 20px 20px;border-bottom:1px solid var(--gray200);margin-bottom:12px;}
+.sb-logo h1{font-size:18px;font-weight:900;color:var(--primary);}
+.sb-logo p{font-size:11px;color:var(--gray400);margin-top:2px;}
+.sb-group{padding:8px 20px 4px;font-size:10px;font-weight:800;color:var(--gray400);letter-spacing:1px;text-transform:uppercase;}
+.sb-link{display:block;padding:8px 20px;font-size:13px;color:var(--gray600);text-decoration:none;border-radius:0;transition:all .15s;border-left:3px solid transparent;}
+.sb-link:hover{background:var(--primary-light);color:var(--primary);}
+.sb-link.active{background:var(--primary-light);color:var(--primary);font-weight:700;border-left-color:var(--primary);}
+.sb-divider{height:1px;background:var(--gray200);margin:12px 0;}
+
+/* ── Page Header ── */
+.page-header{margin-bottom:40px;padding-bottom:24px;border-bottom:2px solid var(--gray200);}
+.page-header h1{font-size:28px;font-weight:900;letter-spacing:-0.5px;color:var(--black);}
+.page-header p{font-size:14px;color:var(--gray600);margin-top:8px;line-height:1.7;}
+.meta-badges{display:flex;gap:8px;margin-top:14px;flex-wrap:wrap;}
+
+/* ── Section ── */
+.section{margin-bottom:56px;}
+.section-title{
+  font-size:20px;font-weight:800;letter-spacing:-0.3px;
+  color:var(--black);margin-bottom:20px;
+  display:flex;align-items:center;gap:10px;
+  padding-bottom:10px;border-bottom:2px solid var(--gray200);
+}
+.section-title .num{
+  background:var(--primary);color:white;
+  width:28px;height:28px;border-radius:8px;
+  display:flex;align-items:center;justify-content:center;
+  font-size:13px;font-weight:800;flex-shrink:0;
+}
+
+/* ── Status Badge ── */
+.badge{
+  display:inline-flex;align-items:center;gap:4px;
+  padding:3px 10px;border-radius:20px;font-size:11px;font-weight:700;
+  white-space:nowrap;
+}
+.badge-done{background:var(--done-bg);color:var(--done);}
+.badge-todo{background:var(--todo-bg);color:#C17A00;}
+.badge-front{background:var(--front-bg);color:#7D3C98;}
+.badge-del{background:var(--del-bg);color:var(--del);}
+.badge-gray{background:var(--gray100);color:var(--gray600);}
+
+/* ── API Card ── */
+.api-card{
+  border:1.5px solid var(--gray200);border-radius:var(--radius);
+  overflow:hidden;margin-bottom:20px;background:white;
+}
+.api-card-header{
+  padding:16px 20px;display:flex;align-items:flex-start;
+  gap:12px;background:var(--gray50);border-bottom:1px solid var(--gray200);
+  flex-wrap:wrap;
+}
+.method{
+  padding:4px 10px;border-radius:6px;font-size:12px;font-weight:800;
+  letter-spacing:0.5px;flex-shrink:0;margin-top:2px;
+}
+.get{background:#E3F2FD;color:#1565C0;}
+.post{background:#E8FAF0;color:#1B8A4B;}
+.put{background:#FFF8EC;color:#C17A00;}
+.patch{background:#F3E5F5;color:#7B1FA2;}
+.delete{background:#FEECEC;color:var(--del);}
+.api-path{font-size:15px;font-weight:700;font-family:'Courier New',monospace;color:var(--black);}
+.api-desc{font-size:13px;color:var(--gray600);margin-top:2px;}
+.api-badges{display:flex;gap:6px;flex-wrap:wrap;margin-top:6px;}
+.api-card-body{padding:20px;}
+
+/* ── Code Block ── */
+pre{
+  background:var(--gray800);color:#E8E8E8;
+  border-radius:8px;padding:16px;overflow-x:auto;
+  font-size:12px;line-height:1.7;font-family:'Courier New',monospace;
+  margin:8px 0;
+}
+pre .key{color:#7EC8E3;}
+pre .str{color:#A8E6A3;}
+pre .num{color:#FFD700;}
+pre .bool{color:#FF8C66;}
+pre .null{color:#FF8C66;}
+pre .comment{color:#888;}
+
+/* ── Table ── */
+table{width:100%;border-collapse:collapse;font-size:13px;margin:10px 0;}
+th{background:var(--gray100);padding:10px 14px;text-align:left;font-weight:700;font-size:12px;color:var(--gray600);border-bottom:2px solid var(--gray200);}
+td{padding:10px 14px;border-bottom:1px solid var(--gray100);vertical-align:top;}
+tr:last-child td{border-bottom:none;}
+tr:hover td{background:var(--gray50);}
+.req{color:var(--del);font-weight:700;font-size:11px;}
+.opt{color:var(--gray400);font-size:11px;}
+code{background:var(--gray100);padding:2px 6px;border-radius:4px;font-family:'Courier New',monospace;font-size:12px;color:var(--primary);}
+.type{color:var(--front);font-family:'Courier New',monospace;font-size:12px;}
+
+/* ── Error Table ── */
+.err-table td:first-child{font-family:'Courier New',monospace;font-size:12px;color:var(--del);font-weight:700;}
+.err-table td:nth-child(2){font-family:'Courier New',monospace;font-size:11px;color:var(--gray600);}
+
+/* ── Screen State Card ── */
+.screen-card{border:1.5px solid var(--gray200);border-radius:var(--radius);overflow:hidden;margin-bottom:20px;background:white;}
+.screen-card-header{padding:16px 20px;background:var(--gray50);border-bottom:1px solid var(--gray200);display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px;}
+.screen-name{font-size:16px;font-weight:800;color:var(--black);}
+.screen-path{font-size:12px;color:var(--gray400);font-family:'Courier New',monospace;margin-top:2px;}
+.screen-card-body{padding:20px;}
+.state-row{display:flex;align-items:flex-start;gap:12px;padding:12px 0;border-bottom:1px solid var(--gray100);}
+.state-row:last-child{border-bottom:none;}
+.state-name{font-size:12px;font-weight:800;min-width:140px;flex-shrink:0;padding-top:2px;}
+.state-desc{font-size:13px;color:var(--gray600);flex:1;line-height:1.6;}
+.state-condition{font-size:11px;color:var(--primary);background:var(--primary-light);padding:2px 8px;border-radius:10px;display:inline-block;margin-top:4px;}
+.state-api{font-size:11px;color:var(--done);background:var(--done-bg);padding:2px 8px;border-radius:10px;display:inline-block;margin-top:4px;}
+
+/* ── Alert Box ── */
+.alert{padding:12px 16px;border-radius:8px;font-size:13px;margin:12px 0;display:flex;gap:10px;align-items:flex-start;line-height:1.6;}
+.alert-warn{background:#FFF8EC;border-left:4px solid var(--todo);color:#7A5C00;}
+.alert-info{background:var(--primary-light);border-left:4px solid var(--primary);color:#3D4FA0;}
+.alert-done{background:var(--done-bg);border-left:4px solid var(--done);color:#155A30;}
+.alert-del{background:var(--del-bg);border-left:4px solid var(--del);color:#8B1A1A;}
+
+/* ── Sub Section ── */
+.sub-title{font-size:14px;font-weight:700;color:var(--gray800);margin:20px 0 10px;display:flex;align-items:center;gap:6px;}
+.sub-title::before{content:'';display:block;width:4px;height:16px;background:var(--primary);border-radius:2px;}
+
+/* ── Tag ── */
+.tag{display:inline-block;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:700;margin:0 2px;}
+.tag-post{background:#E8FAF0;color:#1B8A4B;}
+.tag-get{background:#E3F2FD;color:#1565C0;}
+.tag-patch{background:#F3E5F5;color:#7B1FA2;}
+.tag-put{background:#FFF8EC;color:#C17A00;}
+.tag-del{background:#FEECEC;color:var(--del);}
+
+/* ── TOC scroll ── */
+#toc-toggle{display:none;}
+</style>
+</head>
+<body>
+<div class="layout">
+
+<!-- ── Sidebar ── -->
+<aside class="sidebar">
+  <div class="sb-logo">
+    <h1>retrip</h1>
+    <p>Auth 도메인 명세서 v2.1<br/><span style="font-size:10px;color:#aaa;">최종 업데이트: 2026-04-02</span></p>
+  </div>
+
+  <div class="sb-group">범례</div>
+  <div style="padding:4px 20px 12px;">
+    <div style="display:flex;flex-direction:column;gap:6px;">
+      <span class="badge badge-done">✅ 구현 완료</span>
+      <span class="badge badge-todo">🔧 개발 필요</span>
+      <span class="badge badge-front">🎨 프론트 처리</span>
+      <span class="badge badge-gray">📋 명세 전용</span>
+    </div>
+  </div>
+
+  <div class="sb-divider"></div>
+  <div class="sb-group">API 명세</div>
+  <a class="sb-link" href="#api-auth">인증 (Auth)</a>
+  <a class="sb-link" href="#api-member">회원 (Member)</a>
+  <a class="sb-link" href="#api-social-logic">소셜 로그인 처리 로직 <span class="badge badge-done" style="font-size:10px;">v2.1</span></a>
+  <a class="sb-link" href="#api-profile">프로필 (Profile)</a>
+  <a class="sb-link" href="#api-identity">본인인증 (Identity)</a>
+  <a class="sb-link" href="#api-style">여행 스타일</a>
+  <a class="sb-link" href="#api-response">공통 응답 포맷</a>
+  <a class="sb-link" href="#api-error">에러 코드</a>
+
+  <div class="sb-divider"></div>
+  <div class="sb-group">화면 상태 정의</div>
+  <a class="sb-link" href="#screen-login">로그인 홈</a>
+  <a class="sb-link" href="#screen-email-login">이메일 로그인</a>
+  <a class="sb-link" href="#screen-signup">회원가입 플로우</a>
+  <a class="sb-link" href="#screen-signup-flow">✅ 회원가입 전체 플로우</a>
+  <a class="sb-link" href="#screen-verify-prompt">본인인증 유도 (건너뛰기 가능)</a>
+  <a class="sb-link" href="#screen-my">MY 메인</a>
+  <a class="sb-link" href="#screen-profile-edit">프로필 편집</a>
+  <a class="sb-link" href="#screen-notification">알림 설정</a>
+  <a class="sb-link" href="#screen-history">여행 히스토리</a>
+  <a class="sb-link" href="#screen-account">계정 관리</a>
+  <a class="sb-link" href="#screen-pw-change">비밀번호 변경</a>
+  <a class="sb-link" href="#screen-withdraw">회원 탈퇴</a>
+
+  <div class="sb-divider"></div>
+  <div class="sb-group">정책</div>
+  <a class="sb-link" href="#policy-pw">비밀번호 정책</a>
+  <a class="sb-link" href="#policy-token">토큰 정책</a>
+  <a class="sb-link" href="#policy-social">소셜 로그인 정책</a>
+</aside>
+
+<!-- ── Main Content ── -->
+<main class="content">
+
+<div class="page-header">
+  <h1>Retrip Auth 도메인 — API & 화면 상태 명세서</h1>
+  <p>auth 도메인의 전체 API 엔드포인트와 각 화면의 상태 정의를 담은 명세서입니다.<br/>
+     현재 구현 완료된 항목과 추가 개발이 필요한 항목을 함께 포함합니다.</p>
+  <div class="meta-badges">
+    <span class="badge badge-done">✅ 구현 완료 — 현재 코드에 존재</span>
+    <span class="badge badge-todo">🔧 개발 필요 — 이번 스프린트 추가 구현</span>
+    <span class="badge badge-front">🎨 프론트 처리 — 백엔드 변경 없음</span>
+    <span class="badge badge-gray">📋 다음 배포 — 차기 스프린트</span>
+  </div>
+  <div class="alert alert-info" style="margin-top:16px;">
+    <span>ℹ️</span>
+    <div><strong>Base URL:</strong> <code>http://localhost:8080</code> (로컬) / <code>https://api.retrip.io</code> (운영)<br/>
+    <strong>인증 방식:</strong> JWT Bearer Token — <code>Authorization: Bearer {accessToken}</code><br/>
+    <strong>Content-Type:</strong> <code>application/json</code></div>
+  </div>
+</div>
+
+
+<!-- ════════════════════════════════════════
+     SECTION 1: API — 인증
+════════════════════════════════════════ -->
+<section class="section" id="api-auth">
+  <h2 class="section-title"><div class="num">1</div>API — 인증 (Auth)</h2>
+
+  <!-- 이메일 로그인 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method post">POST</span>
+      <div>
+        <div class="api-path">/login</div>
+        <div class="api-desc">이메일 + 비밀번호 로그인 (LoginAuthenticationFilter 처리)</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔒 인증 불필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="sub-title">Request Body</div>
+      <table>
+        <tr><th>필드</th><th>타입</th><th>필수</th><th>설명</th></tr>
+        <tr><td><code>id</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>이메일 주소 (필드명은 <code>id</code>)</td></tr>
+        <tr><td><code>password</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>비밀번호 (평문 — HTTPS 필수)</td></tr>
+      </table>
+      <pre>{
+  <span class="key">"id"</span>: <span class="str">"user@example.com"</span>,
+  <span class="key">"password"</span>: <span class="str">"Retrip123!"</span>
+}</pre>
+      <div class="sub-title">Response <span style="font-size:12px;color:var(--gray400);">200 OK</span></div>
+      <pre>{
+  <span class="key">"success"</span>: <span class="bool">true</span>,
+  <span class="key">"status"</span>: <span class="num">200</span>,
+  <span class="key">"message"</span>: <span class="str">"OK"</span>,
+  <span class="key">"data"</span>: {
+    <span class="key">"token"</span>: {
+      <span class="key">"accessToken"</span>: <span class="str">"eyJhbGci..."</span>,
+      <span class="key">"refreshToken"</span>: <span class="str">"eyJhbGci..."</span>  <span class="comment">// Set-Cookie로도 전달</span>
+    }
+  }
+}</pre>
+      <div class="sub-title">Error Cases</div>
+      <table class="err-table">
+        <tr><th>HTTP</th><th>code</th><th>message</th><th>상황</th></tr>
+        <tr><td>401</td><td>Member-001</td><td>멤버 엔티티를 찾을 수 없습니다.</td><td>존재하지 않는 이메일</td></tr>
+        <tr><td>401</td><td>Member-002</td><td>비밀 번호가 다릅니다.</td><td>비밀번호 불일치</td></tr>
+        <tr><td>400</td><td>Member-003</td><td>탈퇴한 이메일은 재가입할 수 없습니다.</td><td>탈퇴 계정 로그인 시도</td></tr>
+      </table>
+    </div>
+  </div>
+
+  <!-- 소셜 로그인 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method get">GET</span>
+      <div>
+        <div class="api-path">/oauth2/authorization/{provider}</div>
+        <div class="api-desc">소셜 로그인 리다이렉트 (Spring Security OAuth2 자동 처리)</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔒 인증 불필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <table>
+        <tr><th>필드</th><th>값</th><th>설명</th></tr>
+        <tr><td><code>provider</code> (PathVariable)</td><td><code>kakao</code> / <code>naver</code> / <code>google</code></td><td>소셜 로그인 제공자</td></tr>
+      </table>
+      <div class="alert alert-info">
+        <span>ℹ️</span>
+        <div>로그인 성공 시 <code>OAuth2LoginSuccessHandler</code>가 실행되어 프론트로 리다이렉트됩니다.<br/>
+        <strong>콜백 URL:</strong> <code>http://localhost:3000/auth/callback?accessToken=...&refreshToken=...</code></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 토큰 재발급 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method post">POST</span>
+      <div>
+        <div class="api-path">/auth/reissue</div>
+        <div class="api-desc">Access Token 재발급 (Refresh Token Rotation)</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔒 인증 불필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="alert alert-info"><span>ℹ️</span><div>Request Body 없음. <code>Cookie: refreshToken=...</code> 로 전달</div></div>
+      <div class="sub-title">Response <span style="font-size:12px;color:var(--gray400);">200 OK</span></div>
+      <pre>{
+  <span class="key">"success"</span>: <span class="bool">true</span>,
+  <span class="key">"data"</span>: {
+    <span class="key">"accessToken"</span>: <span class="str">"eyJhbGci..."</span>  <span class="comment">// 새 Access Token</span>
+  }
+}
+<span class="comment">// 새 refreshToken은 Set-Cookie 헤더로 전달</span></pre>
+    </div>
+  </div>
+
+  <!-- 로그아웃 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method post">POST</span>
+      <div>
+        <div class="api-path">/auth/logout</div>
+        <div class="api-desc">현재 기기 로그아웃 — DB의 Refresh Token 삭제</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔒 인증 불필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="alert alert-info"><span>ℹ️</span><div>Cookie의 <code>refreshToken</code> 으로 처리. 응답 시 Cookie 삭제 (Max-Age=0)</div></div>
+      <div class="sub-title">Response <span style="font-size:12px;color:var(--gray400);">200 OK</span></div>
+      <pre>{ <span class="key">"success"</span>: <span class="bool">true</span>, <span class="key">"status"</span>: <span class="num">200</span>, <span class="key">"data"</span>: <span class="null">null</span> }</pre>
+    </div>
+  </div>
+</section>
+
+
+<!-- ════════════════════════════════════════
+     SECTION 2: API — 회원
+════════════════════════════════════════ -->
+<section class="section" id="api-member">
+  <h2 class="section-title"><div class="num">2</div>API — 회원 (Member)</h2>
+
+  <!-- 회원가입 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method post">POST</span>
+      <div>
+        <div class="api-path">/users</div>
+        <div class="api-desc">이메일 회원가입</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔒 인증 불필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="sub-title">Request Body</div>
+      <table>
+        <tr><th>필드</th><th>타입</th><th>필수</th><th>설명/제약</th></tr>
+        <tr><td><code>email</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>이메일 형식 검증</td></tr>
+        <tr><td><code>password</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>8~20자, 영문+숫자+특수문자 포함 <span class="badge badge-todo">🔧 정책 추가 필요</span></td></tr>
+        <tr><td><code>name</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>최대 10자</td></tr>
+        <tr><td><code>gender</code></td><td class="type">String</td><td><span class="req">필수</span></td><td><code>"M"</code> 또는 <code>"F"</code></td></tr>
+        <tr><td><code>birthDate</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>형식: <code>YYYY-MM-DD</code></td></tr>
+        <tr><td><code>nickname</code></td><td class="type">String</td><td><span class="opt">선택</span></td><td>최대 15자. 미입력 시 <code>name</code>으로 자동 설정</td></tr>
+        <tr><td><code>termsAgreed</code></td><td class="type">boolean</td><td><span class="req">필수</span></td><td>필수 약관 동의 (반드시 true)</td></tr>
+        <tr><td><code>marketingAgreed</code></td><td class="type">boolean</td><td><span class="opt">선택</span></td><td>마케팅 수신 동의</td></tr>
+      </table>
+      <pre>{
+  <span class="key">"email"</span>: <span class="str">"user@example.com"</span>,
+  <span class="key">"password"</span>: <span class="str">"Retrip123!"</span>,
+  <span class="key">"name"</span>: <span class="str">"홍길동"</span>,
+  <span class="key">"nickname"</span>: <span class="str">"길동이"</span>,  <span class="comment">// 선택 — 미입력 시 name으로 자동 설정</span>
+  <span class="key">"gender"</span>: <span class="str">"M"</span>,
+  <span class="key">"birthDate"</span>: <span class="str">"1998-03-15"</span>,
+  <span class="key">"termsAgreed"</span>: <span class="bool">true</span>,
+  <span class="key">"marketingAgreed"</span>: <span class="bool">false</span>
+}</pre>
+      <div class="sub-title">Response <span style="font-size:12px;color:var(--gray400);">201 Created</span></div>
+      <pre>{
+  <span class="key">"success"</span>: <span class="bool">true</span>,
+  <span class="key">"status"</span>: <span class="num">201</span>,
+  <span class="key">"data"</span>: {
+    <span class="key">"id"</span>: <span class="str">"550e8400-e29b-41d4-a716-446655440000"</span>,
+    <span class="key">"email"</span>: <span class="str">"user@example.com"</span>,
+    <span class="key">"name"</span>: <span class="str">"홍길동"</span>,
+    <span class="key">"accessToken"</span>: <span class="str">"eyJhbGci..."</span>,
+    <span class="key">"refreshToken"</span>: <span class="str">"eyJhbGci..."</span>  <span class="comment">// Set-Cookie로도 전달</span>
+  }
+}</pre>
+      <div class="sub-title">Error Cases</div>
+      <table class="err-table">
+        <tr><th>HTTP</th><th>code</th><th>message</th><th>상황</th></tr>
+        <tr><td>409</td><td>Member-004</td><td>이미 존재하는 이메일입니다.</td><td>중복 이메일</td></tr>
+        <tr><td>400</td><td>Member-003</td><td>탈퇴한 이메일은 재가입할 수 없습니다.</td><td>탈퇴 계정 이메일로 가입 시도</td></tr>
+      </table>
+    </div>
+  </div>
+
+  <!-- 내 정보 조회 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method get">GET</span>
+      <div>
+        <div class="api-path">/users/me</div>
+        <div class="api-desc">현재 로그인 사용자 기본 정보 조회</div>
+        <div class="api-badges">
+          <span class="badge badge-done">✅ 구현완료</span>
+          <span class="badge badge-gray">🔑 인증 필요</span>
+        </div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="alert alert-done"><span>✅</span><div>v2.1 업데이트: <code>nickname</code>, <code>isVerified</code>, <code>hasPassword</code>, <code>lastLoginProvider</code> 필드 모두 추가 완료.<br/>프론트에서 <code>hasPassword</code> 값으로 소셜 유저 비밀번호 변경 UI 분기 처리하세요.</div></div>
+      <div class="sub-title">Response <span style="font-size:12px;color:var(--gray400);">200 OK</span></div>
+      <pre>{
+  <span class="key">"success"</span>: <span class="bool">true</span>,
+  <span class="key">"data"</span>: {
+    <span class="key">"id"</span>: <span class="str">"550e8400-e29b-41d4-a716-446655440000"</span>,
+    <span class="key">"email"</span>: <span class="str">"user@example.com"</span>,
+    <span class="key">"name"</span>: <span class="str">"홍길동"</span>,
+    <span class="key">"nickname"</span>: <span class="str">"길동이"</span>,           <span class="comment">// 닉네임 (미설정 시 name과 동일)</span>
+    <span class="key">"isVerified"</span>: <span class="bool">false</span>,           <span class="comment">// 본인인증 완료 여부</span>
+    <span class="key">"hasPassword"</span>: <span class="bool">true</span>,            <span class="comment">// 비밀번호 보유 여부. false = 소셜 전용 계정</span>
+    <span class="key">"lastLoginProvider"</span>: <span class="str">"local"</span>,  <span class="comment">// 마지막 로그인 방식: "local" | "kakao" | "naver" | "google"</span>
+    <span class="key">"createdAt"</span>: <span class="str">"2024-03-15T09:41:00"</span>
+  }
+}</pre>
+    </div>
+  </div>
+
+  <!-- 회원 정보 수정 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method put">PUT</span>
+      <div>
+        <div class="api-path">/users</div>
+        <div class="api-desc">회원 기본 정보 수정 (이름, 성별, 생년월일, 비밀번호)</div>
+        <div class="api-badges">
+          <span class="badge badge-done">✅ 구현완료</span>
+
+          <span class="badge badge-gray">🔑 인증 필요</span>
+        </div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="alert alert-done"><span>✅</span><div>v2.1 구현 완료: <code>isVerified == true</code> 인 경우 <code>name</code>, <code>birthDate</code> 변경 시도 시 <code>Member-006</code> 에러 반환.</div></div>
+      <div class="sub-title">Request Body</div>
+      <table>
+        <tr><th>필드</th><th>타입</th><th>필수</th><th>설명</th></tr>
+        <tr><td><code>password</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>현재 비밀번호 (본인 확인용)</td></tr>
+        <tr><td><code>newPassword</code></td><td class="type">String</td><td><span class="opt">선택</span></td><td>새 비밀번호 (변경 시에만)</td></tr>
+        <tr><td><code>name</code></td><td class="type">String</td><td><span class="opt">선택</span></td><td>최대 10자. <strong>isVerified=true면 변경 불가</strong></td></tr>
+        <tr><td><code>gender</code></td><td class="type">String</td><td><span class="opt">선택</span></td><td><code>"M"</code> 또는 <code>"F"</code></td></tr>
+        <tr><td><code>birthDate</code></td><td class="type">String</td><td><span class="opt">선택</span></td><td>YYYY-MM-DD. <strong>isVerified=true면 변경 불가</strong></td></tr>
+      </table>
+      <div class="sub-title">Error Cases</div>
+      <table class="err-table">
+        <tr><th>HTTP</th><th>code</th><th>상황</th></tr>
+        <tr><td>401</td><td>Member-002</td><td>현재 비밀번호 불일치</td></tr>
+        <tr><td>400</td><td>Member-006 <span class="badge badge-todo">🔧 추가</span></td><td>인증 완료 사용자가 이름/생년월일 변경 시도</td></tr>
+      </table>
+    </div>
+  </div>
+
+  <!-- 비밀번호 변경 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method patch">PATCH</span>
+      <div>
+        <div class="api-path">/users/password</div>
+        <div class="api-desc">비밀번호 변경 — 전 기기 강제 로그아웃 (RTR)</div>
+        <div class="api-badges">
+          <span class="badge badge-done">✅ 구현완료</span>
+
+          <span class="badge badge-gray">🔑 인증 필요</span>
+        </div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="alert alert-done"><span>✅</span><div>v2.1 구현 완료: 비밀번호가 없는 소셜 전용 계정 (<code>hasPassword() == false</code>) 이 이 API 호출 시 <code>Member-007 (403)</code> 반환.<br/>프론트에서도 <code>hasPassword</code> 필드 값으로 비밀번호 변경 메뉴 숨김 처리 필요.</div></div>
+      <div class="sub-title">Request Body</div>
+      <table>
+        <tr><th>필드</th><th>타입</th><th>필수</th><th>설명</th></tr>
+        <tr><td><code>currentPassword</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>현재 비밀번호</td></tr>
+        <tr><td><code>newPassword</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>새 비밀번호 (정책 적용)</td></tr>
+      </table>
+      <div class="sub-title">Response <span style="font-size:12px;color:var(--gray400);">200 OK</span></div>
+      <pre>{
+  <span class="key">"data"</span>: {
+    <span class="key">"accessToken"</span>: <span class="str">"eyJhbGci..."</span>,   <span class="comment">// 새 토큰 발급 (기존 기기 토큰 무효화)</span>
+    <span class="key">"refreshToken"</span>: <span class="str">"eyJhbGci..."</span>
+  }
+}</pre>
+    </div>
+  </div>
+
+  <!-- 비밀번호 확인 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method post">POST</span>
+      <div>
+        <div class="api-path">/users/verify-password</div>
+        <div class="api-desc">비밀번호 일치 여부 확인 (탈퇴 전 본인 확인용)</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔑 인증 필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <table>
+        <tr><th>필드</th><th>타입</th><th>설명</th></tr>
+        <tr><td><code>password</code></td><td class="type">String</td><td>확인할 비밀번호</td></tr>
+      </table>
+      <div class="sub-title">Response</div>
+      <pre>{ <span class="key">"data"</span>: { <span class="key">"isValid"</span>: <span class="bool">true</span> } }</pre>
+    </div>
+  </div>
+
+  <!-- 회원 탈퇴 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method delete">DELETE</span>
+      <div>
+        <div class="api-path">/users</div>
+        <div class="api-desc">회원 탈퇴 — Soft Delete (isDeleted=true)</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔑 인증 필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="alert alert-done"><span>✅</span><div>소셜 전용 계정(<code>hasPassword() == false</code>)은 비밀번호 검증을 건너뜁니다. NPE 없이 안전하게 탈퇴 처리됩니다.</div></div>
+      <table>
+        <tr><th>필드</th><th>타입</th><th>설명</th></tr>
+        <tr><td><code>password</code></td><td class="type">String</td><td>현재 비밀번호 (이메일 가입 유저만 필수)</td></tr>
+      </table>
+      <div class="sub-title">Response <span style="font-size:12px;color:var(--gray400);">204 No Content</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ════════════════════════════════════════
+     SECTION 2-B: 소셜 로그인 3단계 처리 로직
+════════════════════════════════════════ -->
+<section class="section" id="api-social-logic">
+  <h2 class="section-title"><div class="num">2B</div>소셜 로그인 3단계 처리 로직 <span class="badge badge-done">✅ v2.1 구현완료</span></h2>
+
+  <div class="alert alert-done">
+    <span>✅</span>
+    <div><strong>feat/social-login-multi-provider-nickname 브랜치 반영 (2026-04-02)</strong><br/>
+    소셜 로그인 시 <code>OAuth2LoginSuccessHandler</code>가 아래 3단계로 처리합니다.<br/>
+    <code>member.provider_id</code> 컬럼이 제거되고 <code>member_social_provider</code> 테이블로 분리됩니다.</div>
+  </div>
+
+  <div class="api-card">
+    <div class="api-card-body">
+      <div class="sub-title">처리 흐름</div>
+      <table>
+        <tr><th>단계</th><th>조건</th><th>처리</th></tr>
+        <tr>
+          <td><strong>1단계</strong><br/><span class="badge badge-done">기존 소셜 계정</span></td>
+          <td><code>member_social_provider</code> 테이블에 동일 <code>providerId</code> 존재</td>
+          <td>로그인 처리 + <code>updateLastLoginProvider(provider)</code> 호출</td>
+        </tr>
+        <tr>
+          <td><strong>2단계</strong><br/><span class="badge badge-done">이메일 자동 연동</span></td>
+          <td>동일 이메일 기존 계정 존재 (로컬 또는 다른 소셜)</td>
+          <td>기존 계정에 새 소셜 providerId 추가 (<code>MemberSocialProvider</code> 신규 저장)</td>
+        </tr>
+        <tr>
+          <td><strong>3단계</strong><br/><span class="badge badge-done">신규 가입</span></td>
+          <td>해당 이메일 계정 없음</td>
+          <td>신규 <code>Member</code> 생성 + <code>MemberSocialProvider</code> 저장</td>
+        </tr>
+      </table>
+
+      <div class="sub-title" style="margin-top:20px;">DB 스키마 변경 (운영 배포 시 수동 DDL 필요)</div>
+      <pre><span class="comment">-- 신규 테이블 (Hibernate ddl-auto: update 로 자동 생성됨)</span>
+CREATE TABLE member_social_provider (
+  id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+  member_id   VARCHAR(36) NOT NULL,
+  provider    VARCHAR(20) NOT NULL,  <span class="comment">-- "kakao" | "naver" | "google"</span>
+  provider_id VARCHAR(255) NOT NULL
+);
+
+<span class="comment">-- 기존 컬럼 제거 (수동 실행 필요 — ddl-auto: update는 컬럼 DROP 안 함)</span>
+ALTER TABLE member DROP COLUMN provider_id;
+
+<span class="comment">-- 신규 컬럼 (Hibernate ddl-auto: update 로 자동 추가됨)</span>
+ALTER TABLE member ADD COLUMN nickname VARCHAR(15);</pre>
+
+      <div class="sub-title" style="margin-top:20px;">주요 설계 원칙</div>
+      <div class="alert alert-info">
+        <span>⚠️</span>
+        <div>
+          <strong>hasPassword() 패턴 — 반드시 준수</strong><br/>
+          소셜 전용 계정 여부를 판단할 때 <code>provider == "local"</code> 비교를 절대 사용하지 않습니다.<br/>
+          항상 <code>member.hasPassword()</code> 메서드를 사용하세요 — 이 메서드는 <code>password != null</code>을 검사합니다.<br/>
+          GET /users/me의 <code>hasPassword</code> 필드를 프론트에서 소셜 유저 UI 분기에 사용하세요.
+        </div>
+      </div>
+
+      <div class="sub-title" style="margin-top:16px;">JWT Payload 변경</div>
+      <pre>{
+  <span class="key">"sub"</span>: <span class="str">"uuid"</span>,
+  <span class="key">"authorities"</span>: <span class="str">"ROLE_USER"</span>,
+  <span class="key">"nickname"</span>: <span class="str">"길동이"</span>  <span class="comment">// v2.1 추가 — trip 서비스 UserContext에서 사용</span>
+}</pre>
+    </div>
+  </div>
+</section>
+
+
+<!-- ════════════════════════════════════════
+     SECTION 3: API — 프로필
+════════════════════════════════════════ -->
+<section class="section" id="api-profile">
+  <h2 class="section-title"><div class="num">3</div>API — 프로필 (Profile)</h2>
+
+  <!-- 프로필 조회 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method get">GET</span>
+      <div>
+        <div class="api-path">/api/users/profile</div>
+        <div class="api-desc">MY 탭 프로필 전체 조회 (여행 스타일 포함)</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔑 인증 필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="sub-title">Response <span style="font-size:12px;color:var(--gray400);">200 OK</span></div>
+      <pre>{
+  <span class="key">"data"</span>: {
+    <span class="key">"email"</span>: <span class="str">"user@example.com"</span>,
+    <span class="key">"name"</span>: <span class="str">"홍길동"</span>,
+    <span class="key">"gender"</span>: <span class="str">"M"</span>,
+    <span class="key">"birthDate"</span>: <span class="str">"1998-03-15"</span>,
+    <span class="key">"isVerified"</span>: <span class="bool">true</span>,         <span class="comment">// ✅ 이미 있음</span>
+    <span class="key">"profileImageUrl"</span>: <span class="str">"https://..."</span>,  <span class="comment">// null이면 기본 아바타 표시 (프론트 처리)</span>
+    <span class="key">"bio"</span>: <span class="str">"사진 찍는 걸 좋아하는 뚜벅이 여행러입니다"</span>,
+    <span class="key">"mbti"</span>: <span class="str">"INFP"</span>,              <span class="comment">// null이면 미설정</span>
+    <span class="key">"travelStyles"</span>: [<span class="str">"계획철저"</span>, <span class="str">"사진광"</span>],
+    <span class="key">"notificationEnabled"</span>: <span class="bool">true</span>
+  }
+}</pre>
+    </div>
+  </div>
+
+  <!-- 프로필 수정 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method put">PUT</span>
+      <div>
+        <div class="api-path">/api/users/profile</div>
+        <div class="api-desc">프로필 수정 (bio, mbti, 프로필이미지, 여행스타일)</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔑 인증 필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="alert alert-info"><span>ℹ️</span><div>이름, 성별, 생년월일은 이 API에서 수정 불가. <code>PUT /users</code> 로 처리.</div></div>
+      <table>
+        <tr><th>필드</th><th>타입</th><th>필수</th><th>제약</th></tr>
+        <tr><td><code>bio</code></td><td class="type">String</td><td><span class="opt">선택</span></td><td>최대 30자</td></tr>
+        <tr><td><code>mbti</code></td><td class="type">String</td><td><span class="opt">선택</span></td><td>최대 4자 (INFP 등). <code>null</code> = 비공개 <span class="badge badge-gray">📋 유효값 검증 다음 배포</span></td></tr>
+        <tr><td><code>profileImageUrl</code></td><td class="type">String</td><td><span class="opt">선택</span></td><td>이미지 URL (S3 등 업로드 후 URL 전달)</td></tr>
+        <tr><td><code>travelStyles</code></td><td class="type">List&lt;String&gt;</td><td><span class="opt">선택</span></td><td>최대 3개. 시스템 제공 키워드만 허용</td></tr>
+      </table>
+    </div>
+  </div>
+
+  <!-- 알림 설정 -->
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method patch">PATCH</span>
+      <div>
+        <div class="api-path">/api/users/notification-settings</div>
+        <div class="api-desc">알림 마스터 토글 ON/OFF</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔑 인증 필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <table>
+        <tr><th>필드</th><th>타입</th><th>필수</th><th>설명</th></tr>
+        <tr><td><code>enabled</code></td><td class="type">Boolean</td><td><span class="req">필수</span></td><td><code>true</code> = 알림 ON / <code>false</code> = 알림 OFF</td></tr>
+      </table>
+      <pre>{ <span class="key">"enabled"</span>: <span class="bool">false</span> }</pre>
+    </div>
+  </div>
+</section>
+
+
+<!-- ════════════════════════════════════════
+     SECTION 4: API — 본인인증
+════════════════════════════════════════ -->
+<section class="section" id="api-identity">
+  <h2 class="section-title"><div class="num">4</div>API — 본인인증 (Identity Verification)</h2>
+
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method post">POST</span>
+      <div>
+        <div class="api-path">/api/auth/verify-identity</div>
+        <div class="api-desc">포트원(PortOne) V2 실명 인증 처리</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔑 인증 필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="alert alert-info"><span>ℹ️</span><div>
+        <strong>플로우:</strong> 프론트에서 PortOne JS SDK로 인증창 호출 → 완료 시 <code>identityVerificationId</code> 수신 → 이 API로 백엔드 전달 → PortOne 서버 검증<br/>
+        <strong>필드명 주의:</strong> DTO는 <code>impUid</code>이지만 실제로는 PortOne V2의 <code>identityVerificationId</code> 값을 담아야 함.
+      </div></div>
+      <table>
+        <tr><th>필드</th><th>타입</th><th>필수</th><th>설명</th></tr>
+        <tr><td><code>impUid</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>PortOne identityVerificationId</td></tr>
+      </table>
+      <pre>{ <span class="key">"impUid"</span>: <span class="str">"identity-verification-id-from-portone"</span> }</pre>
+      <div class="sub-title">Response <span style="font-size:12px;color:var(--gray400);">200 OK</span></div>
+      <pre>{
+  <span class="key">"data"</span>: {
+    <span class="key">"name"</span>: <span class="str">"홍길동"</span>,          <span class="comment">// 인증된 실명으로 업데이트됨</span>
+    <span class="key">"gender"</span>: <span class="str">"M"</span>,
+    <span class="key">"birthDate"</span>: <span class="str">"1998-03-15"</span>,
+    <span class="key">"isVerified"</span>: <span class="bool">true</span>     <span class="comment">// 인증 완료</span>
+  }
+}</pre>
+      <div class="sub-title">Error Cases</div>
+      <table class="err-table">
+        <tr><th>HTTP</th><th>code</th><th>상황</th></tr>
+        <tr><td>409</td><td>Member-005</td><td>동일 CI로 이미 가입된 계정 존재 (중복 가입)</td></tr>
+        <tr><td>500</td><td>Common-007</td><td>PortOne API 호출 실패</td></tr>
+      </table>
+    </div>
+  </div>
+</section>
+
+
+<!-- ════════════════════════════════════════
+     SECTION 5: API — 여행 스타일
+════════════════════════════════════════ -->
+<section class="section" id="api-style">
+  <h2 class="section-title"><div class="num">5</div>API — 여행 스타일 (Travel Style)</h2>
+  <div class="api-card">
+    <div class="api-card-header">
+      <span class="method get">GET</span>
+      <div>
+        <div class="api-path">/api/travel-styles</div>
+        <div class="api-desc">선택 가능한 여행 스타일 전체 목록 조회</div>
+        <div class="api-badges"><span class="badge badge-done">✅ 구현완료</span><span class="badge badge-gray">🔒 인증 불필요</span></div>
+      </div>
+    </div>
+    <div class="api-card-body">
+      <div class="sub-title">Response</div>
+      <pre>{
+  <span class="key">"data"</span>: [
+    { <span class="key">"id"</span>: <span class="num">1</span>, <span class="key">"name"</span>: <span class="str">"계획철저"</span> },
+    { <span class="key">"id"</span>: <span class="num">2</span>, <span class="key">"name"</span>: <span class="str">"즉흥적"</span> },
+    { <span class="key">"id"</span>: <span class="num">3</span>, <span class="key">"name"</span>: <span class="str">"사진광"</span> },
+    { <span class="key">"id"</span>: <span class="num">4</span>, <span class="key">"name"</span>: <span class="str">"맛집탐방"</span> },
+    { <span class="key">"id"</span>: <span class="num">5</span>, <span class="key">"name"</span>: <span class="str">"혼여행가능"</span> },
+    { <span class="key">"id"</span>: <span class="num">6</span>, <span class="key">"name"</span>: <span class="str">"쇼핑러버"</span> },
+    { <span class="key">"id"</span>: <span class="num">7</span>, <span class="key">"name"</span>: <span class="str">"힐링추구"</span> },
+    { <span class="key">"id"</span>: <span class="num">8</span>, <span class="key">"name"</span>: <span class="str">"액티비티"</span> }
+  ]
+}</pre>
+      <div class="alert alert-info"><span>ℹ️</span><div>프로필 편집 화면에서 칩(Chip) UI로 표시. 앱 시작 시 1회 캐싱 권장.</div></div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ════════════════════════════════════════
+     SECTION 6: 공통 응답 포맷
+════════════════════════════════════════ -->
+<section class="section" id="api-response">
+  <h2 class="section-title"><div class="num">6</div>공통 응답 포맷</h2>
+  <div class="api-card">
+    <div class="api-card-body">
+      <div class="sub-title">성공 응답</div>
+      <pre>{
+  <span class="key">"success"</span>: <span class="bool">true</span>,
+  <span class="key">"status"</span>: <span class="num">200</span>,           <span class="comment">// HTTP Status Code</span>
+  <span class="key">"message"</span>: <span class="str">"OK"</span>,          <span class="comment">// HTTP Status 문자열</span>
+  <span class="key">"data"</span>: { <span class="comment">/* 응답 데이터 */</span> }
+}</pre>
+      <div class="sub-title">에러 응답</div>
+      <pre>{
+  <span class="key">"success"</span>: <span class="bool">false</span>,
+  <span class="key">"status"</span>: <span class="num">409</span>,
+  <span class="key">"message"</span>: <span class="str">"Conflict"</span>,
+  <span class="key">"data"</span>: {
+    <span class="key">"status"</span>: <span class="num">409</span>,
+    <span class="key">"code"</span>: <span class="str">"Member-004"</span>,
+    <span class="key">"message"</span>: <span class="str">"이미 존재하는 이메일입니다."</span>
+  }
+}</pre>
+    </div>
+  </div>
+</section>
+
+
+<!-- ════════════════════════════════════════
+     SECTION 7: 에러 코드 전체
+════════════════════════════════════════ -->
+<section class="section" id="api-error">
+  <h2 class="section-title"><div class="num">7</div>에러 코드 전체 목록</h2>
+  <div class="api-card">
+    <div class="api-card-body">
+      <table>
+        <tr><th>code</th><th>HTTP</th><th>message</th><th>상태</th></tr>
+        <tr><td>Common-001</td><td>500</td><td>Server error</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Common-002</td><td>400</td><td>Invalid input value</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Common-003</td><td>403</td><td>Access is denied</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Common-004</td><td>400</td><td>Entity not found</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Common-005</td><td>400</td><td>Illegal state</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Common-006</td><td>403</td><td>접근 권한이 존재하지 않습니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Common-007</td><td>500</td><td>외부 API 호출 중 오류가 발생했습니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Member-001</td><td>401</td><td>멤버 엔티티를 찾을 수 없습니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Member-002</td><td>401</td><td>비밀 번호가 다릅니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Member-003</td><td>400</td><td>탈퇴한 이메일은 재가입할 수 없습니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Member-004</td><td>409</td><td>이미 존재하는 이메일입니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Member-005</td><td>409</td><td>이미 가입된 정보입니다. (CI 중복)</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Member-006</td><td>400</td><td>본인인증 완료 후 이름/생년월일은 변경할 수 없습니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Member-007</td><td>403</td><td>소셜 로그인 회원은 비밀번호를 변경할 수 없습니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+      </table>
+    </div>
+  </div>
+</section>
+
+
+<!-- ════════════════════════════════════════
+     SCREEN STATES
+════════════════════════════════════════ -->
+<div style="background:var(--primary);color:white;padding:16px 0;margin:0 -48px 40px;padding-left:48px;">
+  <h2 style="font-size:22px;font-weight:900;letter-spacing:-0.5px;">화면별 상태 정의</h2>
+  <p style="font-size:13px;opacity:0.8;margin-top:4px;">각 화면에서 발생 가능한 모든 상태와 조건을 정의합니다</p>
+</div>
+
+<!-- 로그인 홈 -->
+<section class="section" id="screen-login">
+  <h2 class="section-title"><div class="num">S1</div>로그인 홈</h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">로그인 홈</div><div class="screen-path">앱 최초 진입 화면</div></div>
+      <div style="display:flex;gap:6px;"><span class="badge badge-front">🎨 프론트</span></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name"><span class="badge badge-gray">default</span></div><div class="state-desc">소셜 로그인 3개 버튼 + 이메일 로그인 버튼 + 이메일 회원가입 버튼 + 비밀번호 찾기 링크 표시<br/><span class="state-api">API 없음</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-gray">loading</span></div><div class="state-desc">소셜 버튼 클릭 시 — 소셜 OAuth 리다이렉트 진행 중. 버튼 비활성화 + 스피너 표시<br/><span class="state-api">GET /oauth2/authorization/{provider}</span></div></div>
+    </div>
+  </div>
+</section>
+
+<!-- 이메일 로그인 -->
+<section class="section" id="screen-email-login">
+  <h2 class="section-title"><div class="num">S2</div>이메일 로그인</h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">이메일 로그인</div><div class="screen-path">로그인 홈 → 이메일 로그인 버튼</div></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name"><span class="badge badge-gray">idle</span></div><div class="state-desc">이메일, 비밀번호 입력 폼. 로그인 버튼 비활성 (미입력 시)</div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-gray">filled</span></div><div class="state-desc">양 필드 입력됨 → 로그인 버튼 활성화</div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-gray">loading</span></div><div class="state-desc">로그인 버튼 클릭 → API 요청 중. 버튼 스피너 + 비활성<br/><span class="state-api">POST /login</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-del">error-auth</span></div><div class="state-desc">401 응답 — "이메일 또는 비밀번호가 일치하지 않습니다" 인라인 에러 표시. 비밀번호 필드 초기화.<br/><span class="state-condition">Member-001 / Member-002</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-del">error-deleted</span></div><div class="state-desc">400 응답 — "탈퇴한 계정입니다. 해당 이메일로 재가입이 불가합니다" 모달 또는 토스트<br/><span class="state-condition">Member-003</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-del">error-network</span></div><div class="state-desc">네트워크 오류 — "잠시 후 다시 시도해주세요" + 재시도 버튼</div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-done">success</span></div><div class="state-desc">accessToken + refreshToken 수신 → 여행 홈(탭 1)으로 이동</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- 회원가입 -->
+<section class="section" id="screen-signup">
+  <h2 class="section-title"><div class="num">S3</div>회원가입 플로우 (3단계)</h2>
+
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">Step 1 — 이메일 & 비밀번호</div></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name">email-idle</div><div class="state-desc">미입력 상태</div></div>
+      <div class="state-row"><div class="state-name">email-validating</div><div class="state-desc">입력 중 — 형식 실시간 검증 (프론트)<br/><span class="state-condition">@이 있고 .도메인 형식인지 확인</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-done">email-valid</span></div><div class="state-desc">✓ 사용 가능한 이메일 형식 (초록색 힌트)</div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-del">email-error</span></div><div class="state-desc">형식 오류 — "올바른 이메일 형식을 입력해 주세요"</div></div>
+      <div class="state-row"><div class="state-name">pw-idle</div><div class="state-desc">미입력 상태</div></div>
+      <div class="state-row"><div class="state-name">pw-typing</div><div class="state-desc">입력 중 — 정책 4가지 실시간 체크 표시 (프론트)<br/>
+        <span class="state-condition">① 8~20자 ② 영문 포함 ③ 숫자 포함 ④ 특수문자(!@#$%^&*-_) 포함</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-done">pw-pass</span></div><div class="state-desc">정책 4가지 모두 통과 — 초록 체크 표시</div></div>
+      <div class="state-row"><div class="state-name">pw-confirm</div><div class="state-desc">비밀번호 확인 — 일치 / 불일치 실시간 표시</div></div>
+      <div class="state-row"><div class="state-name">next-btn</div><div class="state-desc">이메일 형식 OK + 비밀번호 정책 OK + 비밀번호 확인 일치 → "다음" 버튼 활성화<br/><span class="state-condition">중복 이메일 체크는 Step 1에서 실시간 X → 가입 API 호출 시 처리</span></div></div>
+    </div>
+  </div>
+
+  <div class="screen-card" style="margin-top:16px;">
+    <div class="screen-card-header">
+      <div><div class="screen-name">Step 2 — 기본 정보</div></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name">name</div><div class="state-desc">최대 10자 입력. 힌트: "본인인증 완료 시 수정 불가"<br/><span class="state-condition">글자 수 초과 시 입력 차단 또는 에러</span></div></div>
+      <div class="state-row"><div class="state-name">gender</div><div class="state-desc">남성 / 여성 버튼형 선택 (단일 선택). 선택 전 다음 버튼 비활성</div></div>
+      <div class="state-row"><div class="state-name">birthDate</div><div class="state-desc">YYYY-MM-DD 형식. 날짜 피커 또는 직접 입력. 힌트: "본인인증 완료 시 수정 불가"<br/><span class="state-condition">미래 날짜 입력 불가. 100년 이상 과거 불가</span></div></div>
+    </div>
+  </div>
+
+  <div class="screen-card" style="margin-top:16px;">
+    <div class="screen-card-header">
+      <div><div class="screen-name">Step 3 — 약관 동의</div></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name">not-all-required</div><div class="state-desc">필수 약관 미동의 → "가입 완료" 버튼 비활성</div></div>
+      <div class="state-row"><div class="state-name">required-only</div><div class="state-desc">필수 약관만 동의 → "가입 완료" 버튼 활성<br/><span class="state-condition">termsAgreed: true, marketingAgreed: false</span></div></div>
+      <div class="state-row"><div class="state-name">all-agreed</div><div class="state-desc">필수 + 선택 모두 동의<br/><span class="state-condition">termsAgreed: true, marketingAgreed: true</span></div></div>
+      <div class="state-row"><div class="state-name">loading</div><div class="state-desc">"가입 완료" 클릭 → POST /users 호출 중<br/><span class="state-api">POST /users</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-del">error-duplicate</span></div><div class="state-desc">409 응답 — "이미 가입된 이메일입니다" 토스트 + Step 1으로 이동<br/><span class="state-condition">Member-004</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-done">success</span></div><div class="state-desc">
+        201 응답 → <strong>즉시 본인인증 유도 화면으로 자동 이동</strong> (회의 확정 사항)<br/>
+        <span class="state-condition">토큰 저장 후 /verify-identity 라우트로 push (replace X — 뒤로가기 시 로그인홈으로)</span>
+      </div></div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ✅ 회원가입 전체 플로우 (확정) -->
+<section class="section" id="screen-signup-flow">
+  <h2 class="section-title"><div class="num">🗺</div>회원가입 전체 플로우 <span class="badge badge-done" style="font-size:13px;">✅ 회의 확정</span></h2>
+
+  <div class="alert alert-done">
+    <span>✅</span>
+    <div><strong>확정된 플로우:</strong> 회원가입 완료 직후 본인인증 유도 화면으로 <strong>자동 이동</strong>하며, 사용자는 "건너뛰기"로 인증을 나중으로 미룰 수 있습니다.<br/>
+    본인인증은 가입의 필수 단계가 아닌 <strong>선택</strong>이며, 건너뛰어도 서비스 이용이 가능합니다 (인증 뱃지 없음).
+    </div>
+  </div>
+
+  <!-- 플로우 다이어그램 -->
+  <div style="margin:24px 0; overflow-x:auto;">
+    <div style="display:flex; align-items:stretch; gap:0; min-width:700px;">
+
+      <!-- Step 1 -->
+      <div style="flex:1; background:#EEF0FF; border-radius:12px 0 0 12px; padding:16px 12px; text-align:center; border:1.5px solid var(--primary); border-right:none;">
+        <div style="font-size:11px; font-weight:800; color:var(--primary); margin-bottom:4px;">STEP 1</div>
+        <div style="font-size:13px; font-weight:700;">이메일<br/>비밀번호</div>
+        <div style="font-size:11px; color:var(--gray400); margin-top:4px;">형식 검증<br/>정책 검증</div>
+      </div>
+      <div style="display:flex; align-items:center; background:#EEF0FF; border-top:1.5px solid var(--primary); border-bottom:1.5px solid var(--primary); padding:0 4px;"><span style="font-size:18px; color:var(--primary);">→</span></div>
+
+      <!-- Step 2 -->
+      <div style="flex:1; background:#EEF0FF; padding:16px 12px; text-align:center; border:1.5px solid var(--primary); border-left:none; border-right:none;">
+        <div style="font-size:11px; font-weight:800; color:var(--primary); margin-bottom:4px;">STEP 2</div>
+        <div style="font-size:13px; font-weight:700;">이름<br/>성별·생년월일</div>
+        <div style="font-size:11px; color:var(--gray400); margin-top:4px;">최대 10자<br/>YYYY-MM-DD</div>
+      </div>
+      <div style="display:flex; align-items:center; background:#EEF0FF; border-top:1.5px solid var(--primary); border-bottom:1.5px solid var(--primary); padding:0 4px;"><span style="font-size:18px; color:var(--primary);">→</span></div>
+
+      <!-- Step 3 -->
+      <div style="flex:1; background:#EEF0FF; padding:16px 12px; text-align:center; border:1.5px solid var(--primary); border-left:none; border-right:none;">
+        <div style="font-size:11px; font-weight:800; color:var(--primary); margin-bottom:4px;">STEP 3</div>
+        <div style="font-size:13px; font-weight:700;">약관 동의</div>
+        <div style="font-size:11px; color:var(--gray400); margin-top:4px;">필수 / 선택<br/>가입 완료 버튼</div>
+      </div>
+      <div style="display:flex; align-items:center; background:#E8FAF0; border-top:1.5px solid var(--done); border-bottom:1.5px solid var(--done); padding:0 4px;"><span style="font-size:18px; color:var(--done);">→</span></div>
+
+      <!-- API -->
+      <div style="flex:1; background:#E8FAF0; padding:16px 12px; text-align:center; border:1.5px solid var(--done); border-left:none; border-right:none;">
+        <div style="font-size:11px; font-weight:800; color:var(--done); margin-bottom:4px;">API</div>
+        <div style="font-size:12px; font-weight:700; font-family:monospace;">POST /users</div>
+        <div style="font-size:11px; color:var(--gray400); margin-top:4px;">201 Created<br/>토큰 발급</div>
+      </div>
+      <div style="display:flex; align-items:center; background:#FFF3E0; border-top:1.5px solid var(--todo); border-bottom:1.5px solid var(--todo); padding:0 4px;"><span style="font-size:18px; color:var(--todo);">→</span></div>
+
+      <!-- 본인인증 유도 -->
+      <div style="flex:1.3; background:#FFF8EC; padding:16px 12px; text-align:center; border:2px solid var(--todo); border-left:none; border-right:none; position:relative;">
+        <div style="position:absolute; top:-10px; left:50%; transform:translateX(-50%); background:var(--todo); color:white; font-size:10px; font-weight:800; padding:2px 8px; border-radius:10px; white-space:nowrap;">✅ 회의 확정</div>
+        <div style="font-size:11px; font-weight:800; color:#C17A00; margin-bottom:4px;">자동 이동</div>
+        <div style="font-size:13px; font-weight:700;">본인인증 유도</div>
+        <div style="font-size:11px; color:var(--gray600); margin-top:4px;">지금 인증하기<br/>또는 건너뛰기</div>
+      </div>
+
+      <!-- 분기 -->
+      <div style="display:flex; flex-direction:column; gap:0; align-items:center; justify-content:center; min-width:30px; background:#FFF8EC; border-top:2px solid var(--todo); border-bottom:2px solid var(--todo);">
+        <span style="font-size:14px; color:var(--todo);">↗</span>
+        <span style="font-size:14px; color:var(--gray400);">↘</span>
+      </div>
+
+      <!-- 결과 2가지 -->
+      <div style="display:flex; flex-direction:column; gap:6px; flex:1.2;">
+        <div style="flex:1; background:var(--done-bg); border-radius:0 0 0 0; padding:8px 10px; text-align:center; border:1.5px solid var(--done);">
+          <div style="font-size:11px; font-weight:800; color:var(--done);">인증 선택</div>
+          <div style="font-size:11px; color:var(--gray600);">🛡️ 인증뱃지 획득<br/>여행 홈 이동</div>
+        </div>
+        <div style="flex:1; background:var(--gray100); border-radius:0 12px 12px 0; padding:8px 10px; text-align:center; border:1.5px solid var(--gray300);">
+          <div style="font-size:11px; font-weight:800; color:var(--gray600);">건너뛰기</div>
+          <div style="font-size:11px; color:var(--gray600);">미인증 상태<br/>여행 홈 이동</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <div class="alert alert-warn">
+    <span>⚠️</span>
+    <div><strong>백엔드 추가 작업 없음</strong> — 이 플로우는 순수 프론트엔드 라우팅 처리입니다.<br/>
+    <code>POST /users</code> 201 응답 수신 후 프론트에서 <code>/auth/verify-identity</code> 화면으로 navigate.<br/>
+    "건너뛰기" 클릭 시 verify-identity API 호출 없이 여행 홈으로 navigate.<br/>
+    소셜 로그인 최초 진입 시에도 동일한 본인인증 유도 화면 표시.
+    </div>
+  </div>
+</section>
+
+
+<!-- 본인인증 유도 -->
+<section class="section" id="screen-verify-prompt">
+  <h2 class="section-title"><div class="num">S4</div>본인인증 유도 <span class="badge badge-done">✅ 회의 확정 — 가입 직후 자동 진입</span></h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div>
+        <div class="screen-name">본인인증 유도</div>
+        <div class="screen-path">회원가입 완료 직후 자동 이동 / 소셜 최초 로그인 직후 자동 이동</div>
+      </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name">default</div><div class="state-desc">인증 혜택 안내 + "지금 인증하기" + "나중에 하기(건너뛰기)" 버튼</div></div>
+      <div class="state-row"><div class="state-name">verifying</div><div class="state-desc">"지금 인증하기" 클릭 → PortOne JS SDK 인증창 오픈 (프론트 처리)</div></div>
+      <div class="state-row"><div class="state-name">loading</div><div class="state-desc">PortOne 인증 완료 → POST /api/auth/verify-identity 호출 중<br/><span class="state-api">POST /api/auth/verify-identity</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-done">success</span></div><div class="state-desc">인증 완료 → 여행 홈으로 이동. MY 탭에 🛡️ 뱃지 반영</div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-del">error-duplicate-ci</span></div><div class="state-desc">409 — 같은 CI로 가입된 계정 존재. "이미 가입된 정보입니다" 안내<br/><span class="state-condition">Member-005</span></div></div>
+      <div class="state-row"><div class="state-name">skip</div><div class="state-desc">"나중에 하기" 클릭 → 여행 홈으로 이동. isVerified=false 유지</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- MY 메인 -->
+<section class="section" id="screen-my">
+  <h2 class="section-title"><div class="num">S5</div>MY 메인</h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">MY 탭 메인</div><div class="screen-path">하단 네비게이션 3번째 탭</div></div>
+      <div><span class="badge badge-done">GET /api/users/profile</span></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name">loading</div><div class="state-desc">탭 진입 시 프로필 조회 중 — 스켈레톤 UI 표시</div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-gray">미인증</span><br/><code>isVerified=false</code></div><div class="state-desc">
+        • 프로필 상단: 기본 아바타 + 이름 + "미인증" 뱃지(회색)<br/>
+        • 프로필 섹션 아래 <strong>본인인증 CTA 카드 노출</strong><br/>
+        • "신원 확인" 메뉴 항목: "인증하기 →" 표시
+      </div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-done">인증완료</span><br/><code>isVerified=true</code></div><div class="state-desc">
+        • 프로필 상단: 이름 + 🛡️ 인증완료 뱃지(보라/초록)<br/>
+        • 본인인증 CTA 카드 <strong>숨김</strong><br/>
+        • "신원 확인" 메뉴 항목: "완료 · 날짜" 표시 (클릭 불가)
+      </div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-front">소셜 유저</span><br/><code>hasPassword=false</code></div><div class="state-desc">
+        • 계정 관리 섹션에서 비밀번호 변경 메뉴 <strong>숨김 처리</strong><br/>
+        • 해당 소셜 로고 아이콘 표시 (카카오/네이버/구글)<br/>
+        <span class="state-condition">GET /users/me 의 provider 필드 기준</span>
+      </div></div>
+    </div>
+  </div>
+</section>
+
+<!-- 프로필 편집 -->
+<section class="section" id="screen-profile-edit">
+  <h2 class="section-title"><div class="num">S6</div>프로필 편집</h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">프로필 편집</div><div class="screen-path">MY → 프로필 편집</div></div>
+      <div><span class="badge badge-done">PUT /api/users/profile</span></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name">이름 필드<br/><code>isVerified=false</code></div><div class="state-desc">입력 가능. <code>PUT /users</code> 를 통해 변경 (현재 비밀번호 필요)</div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-todo">🔧 이름 필드</span><br/><code>isVerified=true</code></div><div class="state-desc">
+        <strong>잠금 처리</strong> — 입력 비활성화, 🔒 아이콘 + "본인인증 완료 후 수정 불가" 힌트<br/>
+        서버도 동일하게 400 반환 (Member-006)<br/>
+        <span class="state-condition">isVerified=true → UI 잠금 + API 차단 이중 방어</span>
+      </div></div>
+      <div class="state-row"><div class="state-name">bio</div><div class="state-desc">최대 30자. 글자 수 카운터 표시 (우측 상단 "0/30")</div></div>
+      <div class="state-row"><div class="state-name">MBTI</div><div class="state-desc">Select Box — 16가지 유형 + "비공개" 선택지. 미선택 시 null</div></div>
+      <div class="state-row"><div class="state-name">여행 스타일</div><div class="state-desc">칩 UI — 최대 3개 선택. 3개 선택 시 나머지 비활성. 재클릭 시 해제<br/><span class="state-api">GET /api/travel-styles (입장 시 1회 로드)</span></div></div>
+      <div class="state-row"><div class="state-name">프로필 이미지</div><div class="state-desc">탭 → 이미지 선택 → 1:1 크롭 UI → URL 획득 → profileImageUrl로 전달<br/><span class="state-condition">이미지 업로드 방식 팀 논의 필요 (S3 Presigned URL 등)</span></div></div>
+      <div class="state-row"><div class="state-name">loading</div><div class="state-desc">"저장" 탭 시 — 스피너 표시<br/><span class="state-api">PUT /api/users/profile</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-done">success</span></div><div class="state-desc">저장 완료 → 이전 화면으로 이동 + 성공 토스트</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- 알림 설정 -->
+<section class="section" id="screen-notification">
+  <h2 class="section-title"><div class="num">S7</div>알림 설정</h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">알림 설정</div></div>
+      <div><span class="badge badge-done">PATCH /api/users/notification-settings</span></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name">on</div><div class="state-desc">마스터 토글 ON — <code>{ "enabled": true }</code> 전송</div></div>
+      <div class="state-row"><div class="state-name">off</div><div class="state-desc">마스터 토글 OFF — <code>{ "enabled": false }</code> 전송. 토글 즉시 반응 (Optimistic UI)</div></div>
+      <div class="alert alert-info" style="margin-top:12px;"><span>ℹ️</span><div>2차 테스트: 마스터 토글만 구현. 세부 토글(여행/초대/신청 알림)은 다음 배포에서 추가.</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- 여행 히스토리 -->
+<section class="section" id="screen-history">
+  <h2 class="section-title"><div class="num">S8</div>여행 히스토리</h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">여행 히스토리 (초대함 / 신청함)</div><div class="screen-path">MY → 여행 히스토리</div></div>
+      <div><span class="badge badge-gray">📋 trip 도메인 API</span></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="alert alert-warn"><span>⚠️</span><div>초대함/신청함 데이터는 <strong>trip 도메인</strong>에서 제공. auth 도메인 개발 범위 아님.<br/>trip 담당자와 API 명세 별도 논의 필요 (민수민님 요청 사항)</div></div>
+      <div class="state-row"><div class="state-name">탭 구성</div><div class="state-desc">💌 초대함 / 🙋 신청함 — 탭 전환. 각 탭 상단에 미처리 건수 뱃지 표시</div></div>
+      <div class="state-row"><div class="state-name">초대함 상태값</div><div class="state-desc"><code>대기중</code> — 수락/거절 버튼 표시 + 응답 기한 표시 (빨간색)<br/><code>수락</code> — 초록 뱃지. 버튼 없음<br/><code>거절</code> — 빨간 뱃지. 버튼 없음<br/><code>만료</code> — 회색 뱃지. 기한 초과 안내</div></div>
+      <div class="state-row"><div class="state-name">신청함 상태값</div><div class="state-desc"><code>신청중</code> — 노란 뱃지. 결과 대기 중<br/><code>수락됨</code> — 초록 뱃지. "나의 여정에서 확인" 링크<br/><code>거절됨</code> — 빨간 뱃지<br/><code>만료됨</code> — 회색 뱃지</div></div>
+      <div class="state-row"><div class="state-name">empty</div><div class="state-desc">빈 상태 — "아직 받은 초대가 없어요 / 아직 신청한 여행이 없어요" 일러스트 + 메시지</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- 계정 관리 -->
+<section class="section" id="screen-account">
+  <h2 class="section-title"><div class="num">S9</div>계정 관리</h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">계정 관리</div><div class="screen-path">MY → 계정 관리</div></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name"><span class="badge badge-front">이메일 가입</span><br/><code>hasPassword=true</code></div><div class="state-desc">
+        연동 계정: ✉️ 이메일 아이콘 + 이메일 주소 + "현재" 뱃지<br/>
+        비밀번호 변경 메뉴 <strong>표시</strong>
+      </div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-front">소셜 가입</span><br/><code>hasPassword=false</code></div><div class="state-desc">
+        연동 계정: 소셜 아이콘 + 소셜 이메일 + "현재" 뱃지<br/>
+        비밀번호 변경 메뉴 <strong>숨김 처리</strong> (완전히 제거)<br/>
+        <span class="state-condition">GET /users/me 의 <code>hasPassword</code> 필드로 분기 (<code>false</code> = 소셜 전용)</span>
+      </div></div>
+      <div class="state-row"><div class="state-name">로그아웃</div><div class="state-desc">확인 바텀시트 → 확인 클릭 → POST /auth/logout → 로그인 홈으로 이동<br/><span class="state-api">POST /auth/logout</span></div></div>
+    </div>
+  </div>
+</section>
+
+<!-- 비밀번호 변경 -->
+<section class="section" id="screen-pw-change">
+  <h2 class="section-title"><div class="num">S10</div>비밀번호 변경</h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">비밀번호 변경</div><div class="screen-path">계정 관리 → 비밀번호 변경 (이메일 가입 유저만 접근 가능)</div></div>
+      <div><span class="badge badge-done">PATCH /users/password</span></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name">idle</div><div class="state-desc">현재 비밀번호 / 새 비밀번호 / 새 비밀번호 확인 입력 폼</div></div>
+      <div class="state-row"><div class="state-name">new-pw-validating</div><div class="state-desc">새 비밀번호 실시간 정책 체크 (회원가입과 동일한 4가지 규칙 표시)</div></div>
+      <div class="state-row"><div class="state-name">loading</div><div class="state-desc">변경 버튼 클릭 → API 호출 중</div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-del">error-current</span></div><div class="state-desc">401 응답 — "현재 비밀번호가 일치하지 않습니다" 인라인 에러<br/><span class="state-condition">Member-002</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-done">success</span></div><div class="state-desc">
+        200 응답 → <strong>전 기기 강제 로그아웃</strong> (RTR 정책)<br/>
+        "비밀번호가 변경되었습니다. 다시 로그인해 주세요" 안내 모달<br/>
+        → 로그인 홈으로 이동 (현재 기기 토큰 교체됨)
+      </div></div>
+    </div>
+  </div>
+</section>
+
+<!-- 회원 탈퇴 -->
+<section class="section" id="screen-withdraw">
+  <h2 class="section-title"><div class="num">S11</div>회원 탈퇴</h2>
+  <div class="screen-card">
+    <div class="screen-card-header">
+      <div><div class="screen-name">회원 탈퇴</div><div class="screen-path">계정 관리 → 회원 탈퇴</div></div>
+      <div><span class="badge badge-done">DELETE /users</span></div>
+    </div>
+    <div class="screen-card-body">
+      <div class="state-row"><div class="state-name">step1-안내</div><div class="state-desc">
+        탈퇴 시 삭제되는 항목 안내 (프로필, 여행 기록, 인증 정보 등)<br/>
+        "계속하기" 버튼 → step2로 이동
+      </div></div>
+      <div class="state-row"><div class="state-name">step2-확인<br/><code>hasPassword=true</code></div><div class="state-desc">
+        비밀번호 재입력 폼 + "탈퇴하기" 버튼 (빨간색)<br/>
+        <span class="state-api">POST /users/verify-password 로 선확인 후 DELETE /users</span>
+      </div></div>
+      <div class="state-row"><div class="state-name">step2-확인<br/><code>hasPassword=false</code></div><div class="state-desc">
+        비밀번호 입력 없이 최종 확인 텍스트만 표시<br/>
+        "정말 탈퇴하시겠습니까?" + "탈퇴하기" 버튼<br/>
+        <span class="state-condition">✅ DELETE /users 에서 소셜 전용 계정 비밀번호 검증 건너뜀 (NPE 없음)</span>
+      </div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-del">error-pw</span></div><div class="state-desc">비밀번호 불일치 — "비밀번호가 올바르지 않습니다"<br/><span class="state-condition">Member-002</span></div></div>
+      <div class="state-row"><div class="state-name"><span class="badge badge-done">success</span></div><div class="state-desc">204 응답 → "그동안 리트립을 이용해주셔서 감사합니다" 모달 → 로그인 홈으로 이동</div></div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ════════════════════════════════════════
+     POLICY
+════════════════════════════════════════ -->
+<div style="background:var(--gray800);color:white;padding:16px 0;margin:0 -48px 40px;padding-left:48px;">
+  <h2 style="font-size:22px;font-weight:900;letter-spacing:-0.5px;">정책 정의</h2>
+</div>
+
+<section class="section" id="policy-pw">
+  <h2 class="section-title"><div class="num">P1</div>비밀번호 정책 (업계 표준)</h2>
+  <div class="api-card">
+    <div class="api-card-body">
+      <table>
+        <tr><th>항목</th><th>정책</th><th>근거</th></tr>
+        <tr><td>최소 길이</td><td><strong>8자</strong></td><td>NIST SP 800-63B, 카카오/네이버 동일</td></tr>
+        <tr><td>최대 길이</td><td><strong>20자</strong></td><td>국내 서비스 일반적 기준</td></tr>
+        <tr><td>필수 조합</td><td>영문 + 숫자 + 특수문자 <strong>3가지 모두 포함</strong></td><td>카카오, 네이버 기준</td></tr>
+        <tr><td>허용 특수문자</td><td><code>! @ # $ % ^ & * ( ) - _ = + [ ] | ; : , . /</code></td><td>공백, 따옴표 등 제외</td></tr>
+        <tr><td>정규식</td><td colspan="2"><code>^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()\-_=+\[\]|;:,.\/]).{8,20}$</code></td></tr>
+      </table>
+      <div class="alert alert-done" style="margin-top:12px;"><span>✅</span><div>혁진님과 협의 후 특수문자 목록 확정 필요. 위 목록을 기본안으로 사용 권장.</div></div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="policy-token">
+  <h2 class="section-title"><div class="num">P2</div>토큰 정책</h2>
+  <div class="api-card">
+    <div class="api-card-body">
+      <table>
+        <tr><th>토큰</th><th>만료 시간</th><th>저장 위치</th><th>비고</th></tr>
+        <tr><td>Access Token</td><td><strong>120분</strong></td><td>메모리 (프론트)</td><td>Authorization 헤더로 전달</td></tr>
+        <tr><td>Refresh Token</td><td><strong>2년</strong> (1,051,200분)</td><td>HttpOnly Cookie + DB</td><td>Cookie: httpOnly, secure, sameSite=None, maxAge=14일</td></tr>
+      </table>
+      <div class="alert alert-warn" style="margin-top:12px;"><span>⚠️</span><div>Refresh Token DB 만료 기간(2년)과 Cookie maxAge(14일) 불일치. 실제로는 Cookie 기준으로 만료됨. 팀 논의 후 통일 권장.</div></div>
+    </div>
+  </div>
+</section>
+
+<section class="section" id="policy-social">
+  <h2 class="section-title"><div class="num">P3</div>소셜 로그인 정책</h2>
+  <div class="api-card">
+    <div class="api-card-body">
+      <table>
+        <tr><th>항목</th><th>정책</th></tr>
+        <tr><td>내부 관리</td><td>소셜 가입도 이메일 기반 회원으로 통합 관리. 소셜 provider 정보는 <code>member_social_provider</code> 테이블로 분리 관리</td></tr>
+        <tr><td>비밀번호</td><td>소셜 전용 계정은 <code>password = null</code> → <code>hasPassword() == false</code>. 비밀번호 변경 불가 (API 403 + UI 숨김)</td></tr>
+        <tr><td>이메일 충돌</td><td>소셜 로그인 시 동일 이메일 기존 계정 존재 → 기존 계정에 소셜 provider 자동 연동 (Section 2B 참조)</td></tr>
+        <tr><td>탈퇴</td><td>소셜 유저 탈퇴 시 비밀번호 없이 확인만 받고 DELETE 처리 → 소셜 provider 측 연결 해제는 별도</td></tr>
+        <tr><td>약관 동의</td><td>소셜 최초 로그인 시 필수 약관 동의 화면 진입 필요 (현재 자동 처리 여부 확인 필요)</td></tr>
+      </table>
+    </div>
+  </div>
+</section>
+
+</main>
+</div>
+
+<script>
+// Sidebar active link on scroll
+const sections = document.querySelectorAll('section[id]');
+const links = document.querySelectorAll('.sb-link');
+
+function updateActive(){
+  let current = '';
+  sections.forEach(s => {
+    const top = s.getBoundingClientRect().top;
+    if(top < 120) current = s.id;
+  });
+  links.forEach(l => {
+    l.classList.toggle('active', l.getAttribute('href') === '#' + current);
+  });
+}
+window.addEventListener('scroll', updateActive, {passive:true});
+updateActive();
+</script>
+</body>
+</html>

--- a/docs/spec.html
+++ b/docs/spec.html
@@ -177,7 +177,7 @@ code{background:var(--gray100);padding:2px 6px;border-radius:4px;font-family:'Co
 <aside class="sidebar">
   <div class="sb-logo">
     <h1>retrip</h1>
-    <p>Auth 도메인 명세서 v2.1<br/><span style="font-size:10px;color:#aaa;">최종 업데이트: 2026-04-02</span></p>
+    <p>Auth 도메인 명세서 v2.2<br/><span style="font-size:10px;color:#aaa;">최종 업데이트: 2026-04-04</span></p>
   </div>
 
   <div class="sb-group">범례</div>
@@ -287,8 +287,7 @@ code{background:var(--gray100);padding:2px 6px;border-radius:4px;font-family:'Co
       <div class="sub-title">Error Cases</div>
       <table class="err-table">
         <tr><th>HTTP</th><th>code</th><th>message</th><th>상황</th></tr>
-        <tr><td>401</td><td>Member-001</td><td>멤버 엔티티를 찾을 수 없습니다.</td><td>존재하지 않는 이메일</td></tr>
-        <tr><td>401</td><td>Member-002</td><td>비밀 번호가 다릅니다.</td><td>비밀번호 불일치</td></tr>
+        <tr><td>401</td><td>Member-001</td><td>멤버 엔티티를 찾을 수 없습니다.</td><td>존재하지 않는 이메일 또는 비밀번호 불일치 (보안상 통합 응답)</td></tr>
         <tr><td>400</td><td>Member-003</td><td>탈퇴한 이메일은 재가입할 수 없습니다.</td><td>탈퇴 계정 로그인 시도</td></tr>
       </table>
     </div>
@@ -380,8 +379,8 @@ code{background:var(--gray100);padding:2px 6px;border-radius:4px;font-family:'Co
       <table>
         <tr><th>필드</th><th>타입</th><th>필수</th><th>설명/제약</th></tr>
         <tr><td><code>email</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>이메일 형식 검증</td></tr>
-        <tr><td><code>password</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>8~20자, 영문+숫자+특수문자 포함 <span class="badge badge-todo">🔧 정책 추가 필요</span></td></tr>
-        <tr><td><code>name</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>최대 10자</td></tr>
+        <tr><td><code>password</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>8~20자, 영문+숫자+특수문자 포함 <span class="badge badge-done">✅ 서버 검증 완료</span></td></tr>
+        <tr><td><code>name</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>최대 10자, 한글·영문만 허용 (숫자·특수문자 불가) <span class="badge badge-done">✅ 서버 검증 완료</span></td></tr>
         <tr><td><code>gender</code></td><td class="type">String</td><td><span class="req">필수</span></td><td><code>"M"</code> 또는 <code>"F"</code></td></tr>
         <tr><td><code>birthDate</code></td><td class="type">String</td><td><span class="req">필수</span></td><td>형식: <code>YYYY-MM-DD</code></td></tr>
         <tr><td><code>nickname</code></td><td class="type">String</td><td><span class="opt">선택</span></td><td>최대 15자. 미입력 시 <code>name</code>으로 자동 설정</td></tr>
@@ -413,6 +412,8 @@ code{background:var(--gray100);padding:2px 6px;border-radius:4px;font-family:'Co
       <div class="sub-title">Error Cases</div>
       <table class="err-table">
         <tr><th>HTTP</th><th>code</th><th>message</th><th>상황</th></tr>
+        <tr><td>400</td><td>Member-009</td><td>필수 약관에 동의해야 합니다.</td><td>termsAgreed=false</td></tr>
+        <tr><td>400</td><td>Common-002</td><td>Invalid input value</td><td>이메일 형식 오류 / 비밀번호 정책 미달 / 이름 형식 오류 / 생년월일 형식·범위 오류</td></tr>
         <tr><td>409</td><td>Member-004</td><td>이미 존재하는 이메일입니다.</td><td>중복 이메일</td></tr>
         <tr><td>400</td><td>Member-003</td><td>탈퇴한 이메일은 재가입할 수 없습니다.</td><td>탈퇴 계정 이메일로 가입 시도</td></tr>
       </table>
@@ -480,7 +481,7 @@ code{background:var(--gray100);padding:2px 6px;border-radius:4px;font-family:'Co
       <table class="err-table">
         <tr><th>HTTP</th><th>code</th><th>상황</th></tr>
         <tr><td>401</td><td>Member-002</td><td>현재 비밀번호 불일치</td></tr>
-        <tr><td>400</td><td>Member-006 <span class="badge badge-todo">🔧 추가</span></td><td>인증 완료 사용자가 이름/생년월일 변경 시도</td></tr>
+        <tr><td>400</td><td>Member-006</td><td>인증 완료 사용자가 이름/생년월일 변경 시도</td></tr>
       </table>
     </div>
   </div>
@@ -840,6 +841,8 @@ ALTER TABLE member ADD COLUMN nickname VARCHAR(15);</pre>
         <tr><td>Member-005</td><td>409</td><td>이미 가입된 정보입니다. (CI 중복)</td><td><span class="badge badge-done">✅</span></td></tr>
         <tr><td>Member-006</td><td>400</td><td>본인인증 완료 후 이름/생년월일은 변경할 수 없습니다.</td><td><span class="badge badge-done">✅</span></td></tr>
         <tr><td>Member-007</td><td>403</td><td>소셜 로그인 회원은 비밀번호를 변경할 수 없습니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Member-008</td><td>409</td><td>이미 비밀번호가 설정된 계정입니다.</td><td><span class="badge badge-done">✅</span></td></tr>
+        <tr><td>Member-009</td><td>400</td><td>필수 약관에 동의해야 합니다.</td><td><span class="badge badge-done">✅</span></td></tr>
       </table>
     </div>
   </div>

--- a/src/main/java/com/retrip/auth/application/config/CustomUserDetails.java
+++ b/src/main/java/com/retrip/auth/application/config/CustomUserDetails.java
@@ -66,6 +66,10 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
     public String getBirthDate() {
         return member.getBirthDate();
     }
+
+    public String getNickname() {
+        return member.getNickname();
+    }
     // =============================================================
 
     // OAuth2User 메서드

--- a/src/main/java/com/retrip/auth/application/config/CustomUserDetails.java
+++ b/src/main/java/com/retrip/auth/application/config/CustomUserDetails.java
@@ -37,8 +37,7 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
     @Override
     public String getPassword() {
-        // VO에서 값 꺼내기
-        return member.getPassword().getValue();
+        return member.getPassword() != null ? member.getPassword().getValue() : null;
     }
 
     @Override

--- a/src/main/java/com/retrip/auth/application/config/JwtProvider.java
+++ b/src/main/java/com/retrip/auth/application/config/JwtProvider.java
@@ -37,6 +37,7 @@ public class JwtProvider {
         String memberId = authentication.getName();
         String email = "";
         String name = "";
+        String nickname = null;
         String gender = null;
         String birthDate = null;
 
@@ -45,19 +46,20 @@ public class JwtProvider {
             memberId = userDetails.getName();
             email = userDetails.getEmail();
             name = userDetails.getRealName();
+            nickname = userDetails.getNickname();
             gender = userDetails.getGender();
             birthDate = userDetails.getBirthDate();
         } else {
             memberId = authentication.getName();
         }
 
-        String accessToken = createToken(memberId, email, name, gender, birthDate, authorities, now, jwtConfig.getAccess().getExpireMin());
-        String refreshToken = createToken(memberId, email, name, gender, birthDate, authorities, now, jwtConfig.getRefresh().getExpireMin());
+        String accessToken = createToken(memberId, email, name, nickname, gender, birthDate, authorities, now, jwtConfig.getAccess().getExpireMin());
+        String refreshToken = createToken(memberId, email, name, nickname, gender, birthDate, authorities, now, jwtConfig.getRefresh().getExpireMin());
 
         return new LoginResponse.TokenResponse(accessToken, refreshToken);
     }
 
-    private String createToken(String subject, String email, String name, String gender, String birthDate,
+    private String createToken(String subject, String email, String name, String nickname, String gender, String birthDate,
                                String authorities, Instant issuedAt, long expirationMinutes) {
         try {
             PrivateKey privateKey = getPrivateKey(jwtConfig.getPrivateKey());
@@ -69,6 +71,7 @@ public class JwtProvider {
                     .claim("name", name)
                     .claim("authorities", authorities); // 권한이 없으면 빈 문자열 ""이 들어감
 
+            if (nickname != null) builder.claim("nickname", nickname);
             if (gender != null) builder.claim("gender", gender);
             if (birthDate != null) builder.claim("birthDate", birthDate);
 
@@ -95,6 +98,7 @@ public class JwtProvider {
             String memberId = claims.getSubject();
             String email = claims.get("username", String.class);
             String name = claims.get("name", String.class);
+            String nickname = claims.get("nickname", String.class);
             String authoritiesStr = claims.get("authorities", String.class);
             String gender = claims.get("gender", String.class);
             String birthDate = claims.get("birthDate", String.class);
@@ -114,6 +118,7 @@ public class JwtProvider {
                     .id(UUID.fromString(memberId))
                     .email(new MemberEmail(email))
                     .name(new MemberName(name))
+                    .nickname(nickname)
                     .gender(gender)
                     .birthDate(birthDate)
                     .password(null)

--- a/src/main/java/com/retrip/auth/application/config/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/retrip/auth/application/config/OAuth2LoginSuccessHandler.java
@@ -1,18 +1,21 @@
-package com.retrip.auth.application.config; // SecurityConfig와 같은 위치에 둡니다.
+package com.retrip.auth.application.config;
 
+import com.retrip.auth.application.in.AuthService;
 import com.retrip.auth.application.in.response.LoginResponse;
-import io.jsonwebtoken.Jwts;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -20,8 +23,10 @@ import java.nio.charset.StandardCharsets;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtProvider jwtProvider;
+    private final AuthService authService;
 
-    private static final String FRONTEND_CALLBACK_URL = "http://localhost:3000/auth/callback";
+    @Value("${app.frontend-callback-url:http://localhost:3000/auth/callback}")
+    private String frontendCallbackUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -29,7 +34,11 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         LoginResponse.TokenResponse tokenResponse = jwtProvider.generateTokens(authentication);
 
-        String targetUrl = UriComponentsBuilder.fromUriString(FRONTEND_CALLBACK_URL)
+        // RefreshToken DB 저장 (소셜 로그인 로그아웃 지원)
+        UUID memberId = UUID.fromString(authentication.getName());
+        authService.saveRefreshToken(tokenResponse.refreshToken(), memberId);
+
+        String targetUrl = UriComponentsBuilder.fromUriString(frontendCallbackUrl)
                 .queryParam("accessToken", tokenResponse.accessToken())
                 .queryParam("refreshToken", tokenResponse.refreshToken())
                 .build()

--- a/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
+++ b/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.retrip.auth.application.config;
 
 import com.retrip.auth.application.in.CustomOAuth2UserService;
 import com.retrip.auth.application.in.MemberQueryService;
+import com.retrip.auth.application.out.repository.MemberRepository;
 import com.retrip.auth.application.out.repository.RefreshTokenRepository;
 import com.retrip.auth.infra.adapter.in.rest.filter.JwtAuthenticationFilter;
 import com.retrip.auth.infra.adapter.in.rest.filter.LoginAuthenticationFilter;
@@ -39,6 +40,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberRepository memberRepository;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
@@ -67,8 +69,7 @@ public class SecurityConfig {
             JwtConfig jwtConfig,
             AuthenticationManager authenticationManager,
             JwtProvider jwtProvider) {
-        LoginAuthenticationFilter filter = new LoginAuthenticationFilter(jwtConfig, authenticationManager, jwtProvider, refreshTokenRepository);
-        return filter;
+        return new LoginAuthenticationFilter(jwtConfig, authenticationManager, jwtProvider, refreshTokenRepository, memberRepository);
     }
 
     @Bean

--- a/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
+++ b/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
@@ -134,6 +134,7 @@ public class SecurityConfig {
         config.setAllowedOriginPatterns(List.of(
                 "http://localhost:*",
                 "http://127.0.0.1:*",
+                "https://retrip-web.vercel.app",
                 "https://retrip-web-*.vercel.app",
                 "https://retrip.io",
                 "https://*.retrip.io"

--- a/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
+++ b/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.retrip.auth.infra.adapter.in.rest.filter.JwtAuthenticationFilter;
 import com.retrip.auth.infra.adapter.in.rest.filter.LoginAuthenticationFilter;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -64,12 +65,15 @@ public class SecurityConfig {
         return authenticationManagerBuilder.build();
     }
 
+    @Value("${app.cookie.secure:true}")
+    private boolean cookieSecure;
+
     @Bean
     public LoginAuthenticationFilter loginAuthenticationFilter(
             JwtConfig jwtConfig,
             AuthenticationManager authenticationManager,
             JwtProvider jwtProvider) {
-        return new LoginAuthenticationFilter(jwtConfig, authenticationManager, jwtProvider, refreshTokenRepository, memberRepository);
+        return new LoginAuthenticationFilter(jwtConfig, authenticationManager, jwtProvider, refreshTokenRepository, memberRepository, cookieSecure);
     }
 
     @Bean

--- a/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
+++ b/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
@@ -114,7 +114,6 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/users", "/api/users").permitAll()
                         .requestMatchers("/login/**", "/oauth2/**", "/auth/reissue", "/auth/logout", "/").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
-                        .requestMatchers("/debug/**").permitAll()
                         // ✅ 추가: 본인인증 및 여행 스타일 조회 API 허용
                         .requestMatchers(HttpMethod.GET, "/api/travel-styles").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/auth/verify-identity").authenticated()
@@ -128,11 +127,12 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        // 개발 환경: 모든 localhost 포트 허용
         config.setAllowedOriginPatterns(List.of(
                 "http://localhost:*",
                 "http://127.0.0.1:*",
-                "https://retrip-web-*.vercel.app"
+                "https://retrip-web-*.vercel.app",
+                "https://retrip.io",
+                "https://*.retrip.io"
         ));
 
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));

--- a/src/main/java/com/retrip/auth/application/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/retrip/auth/application/dto/request/UpdateProfileRequest.java
@@ -10,6 +10,9 @@ import java.util.List;
 @NoArgsConstructor
 public class UpdateProfileRequest {
 
+    @Size(max = 15, message = "닉네임은 최대 15자까지 입력 가능합니다.")
+    private String nickname;
+
     @Size(max = 30, message = "소개는 최대 30자까지 입력 가능합니다.")
     private String bio;
 

--- a/src/main/java/com/retrip/auth/application/dto/response/ProfileResponse.java
+++ b/src/main/java/com/retrip/auth/application/dto/response/ProfileResponse.java
@@ -1,9 +1,11 @@
 package com.retrip.auth.application.dto.response;
 
 import com.retrip.auth.domain.entity.Member;
+import com.retrip.auth.domain.entity.MemberSocialProvider;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -11,6 +13,7 @@ import java.util.List;
 public class ProfileResponse {
     private String email;
     private String name;
+    private String nickname;
     private String gender;
     private String birthDate;
     private Boolean isVerified;
@@ -19,11 +22,22 @@ public class ProfileResponse {
     private String mbti;
     private List<String> travelStyles;
     private Boolean notificationEnabled;
+    private Boolean hasPassword;
+    private String lastLoginProvider;
+    private List<LinkedProviderInfo> linkedProviders;
 
-    public static ProfileResponse from(Member member, List<String> travelStyles) {
+    public record LinkedProviderInfo(String provider, LocalDateTime linkedAt) {}
+
+    public static ProfileResponse from(Member member, List<String> travelStyles,
+                                       List<MemberSocialProvider> socialProviders) {
+        List<LinkedProviderInfo> linked = socialProviders.stream()
+                .map(sp -> new LinkedProviderInfo(sp.getProvider(), sp.getLinkedAt()))
+                .toList();
+
         return ProfileResponse.builder()
                 .email(member.getEmailValue())
                 .name(member.getNameValue())
+                .nickname(member.getNickname())
                 .gender(member.getGender())
                 .birthDate(member.getBirthDate())
                 .isVerified(member.isVerified())
@@ -32,6 +46,9 @@ public class ProfileResponse {
                 .mbti(member.getMbti())
                 .travelStyles(travelStyles)
                 .notificationEnabled(member.isNotificationEnabled())
+                .hasPassword(member.hasPassword())
+                .lastLoginProvider(member.getProvider())
+                .linkedProviders(linked)
                 .build();
     }
 }

--- a/src/main/java/com/retrip/auth/application/in/AuthService.java
+++ b/src/main/java/com/retrip/auth/application/in/AuthService.java
@@ -1,5 +1,6 @@
 package com.retrip.auth.application.in;
 
+import com.retrip.auth.application.config.CustomUserDetails;
 import com.retrip.auth.application.config.JwtProvider;
 import com.retrip.auth.application.in.response.LoginResponse;
 import com.retrip.auth.application.out.repository.MemberRepository;
@@ -52,10 +53,12 @@ public class AuthService {
             throw new BadCredentialsException("탈퇴한 회원입니다.");
         }
 
+        // CustomUserDetails로 Authentication 생성 → email/name/nickname 등 클레임 정상 포함
+        CustomUserDetails userDetails = new CustomUserDetails(member);
         Authentication authentication = new UsernamePasswordAuthenticationToken(
-                memberId,
+                userDetails,
                 null,
-                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                userDetails.getAuthorities()
         );
 
         LoginResponse.TokenResponse newTokens = jwtProvider.generateTokens(authentication);

--- a/src/main/java/com/retrip/auth/application/in/CustomOAuth2UserService.java
+++ b/src/main/java/com/retrip/auth/application/in/CustomOAuth2UserService.java
@@ -2,7 +2,9 @@ package com.retrip.auth.application.in;
 
 import com.retrip.auth.application.config.CustomUserDetails;
 import com.retrip.auth.application.out.repository.MemberRepository;
+import com.retrip.auth.application.out.repository.MemberSocialProviderRepository;
 import com.retrip.auth.domain.entity.Member;
+import com.retrip.auth.domain.entity.MemberSocialProvider;
 import com.retrip.auth.domain.vo.MemberEmail;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,7 @@ import java.util.Optional;
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
+    private final MemberSocialProviderRepository socialProviderRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -39,22 +42,44 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private Member saveOrUpdate(OAuthAttributes attributes) {
-        Optional<Member> memberOptional = memberRepository.findByEmailAndIsDeletedFalse(new MemberEmail(attributes.getEmail()))
+
+        // Step 1: providerId로 기존 연동 확인 (재로그인)
+        Optional<MemberSocialProvider> existingSocial =
+                socialProviderRepository.findByProviderAndProviderId(
+                        attributes.getProvider(), attributes.getProviderId());
+
+        if (existingSocial.isPresent()) {
+            Member member = memberRepository.findById(existingSocial.get().getMemberId())
+                    .orElseThrow(() -> new OAuth2AuthenticationException("연동된 멤버를 찾을 수 없습니다."));
+            member.updateLastLoginProvider(attributes.getProvider());
+            log.info("소셜 재로그인: {} ({})", attributes.getEmail(), attributes.getProvider());
+            return member;
+        }
+
+        // Step 2: 이메일로 기존 계정 확인 (다른 소셜 or 이메일 계정 → 자동 연동)
+        Optional<Member> existingMember = memberRepository
+                .findByEmailAndIsDeletedFalse(new MemberEmail(attributes.getEmail()))
                 .stream().findFirst();
 
-        Member member;
-        if (memberOptional.isPresent()) {
-            member = memberOptional.get();
-            if (member.getProvider() == null || member.getProvider().equals("local")) {
-                log.warn("기존 로컬 계정({})으로 소셜 로그인을 시도했습니다.", attributes.getEmail());
-                // TODO: 추후 계정 연동 정책에 따라 로직 수정 필요 (현재는 정보 업데이트만 수행)
+        if (existingMember.isPresent()) {
+            Member member = existingMember.get();
+            if (!socialProviderRepository.existsByMemberIdAndProvider(member.getId(), attributes.getProvider())) {
+                socialProviderRepository.save(
+                        MemberSocialProvider.create(member.getId(), attributes.getProvider(),
+                                attributes.getProviderId(), attributes.getEmail()));
             }
-            member.updateSocialInfo(attributes.getName());
-        } else {
-            member = attributes.toEntity();
-            memberRepository.save(member);
-            log.info("신규 소셜 회원 가입: {} ({})", attributes.getEmail(), attributes.getProvider());
+            member.updateLastLoginProvider(attributes.getProvider());
+            log.info("소셜 계정 연동: {} → {}", attributes.getEmail(), attributes.getProvider());
+            return member;
         }
-        return member;
+
+        // Step 3: 신규 가입
+        Member newMember = attributes.toEntity();
+        memberRepository.save(newMember);
+        socialProviderRepository.save(
+                MemberSocialProvider.create(newMember.getId(), attributes.getProvider(),
+                        attributes.getProviderId(), attributes.getEmail()));
+        log.info("신규 소셜 회원 가입: {} ({})", attributes.getEmail(), attributes.getProvider());
+        return newMember;
     }
 }

--- a/src/main/java/com/retrip/auth/application/in/CustomOAuth2UserService.java
+++ b/src/main/java/com/retrip/auth/application/in/CustomOAuth2UserService.java
@@ -38,6 +38,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         Member member = saveOrUpdate(attributes);
 
+        // Hibernate 세션이 닫히기 전에 authorities 강제 초기화 (LazyInitializationException 방지)
+        member.getAuthorities().getValues().size();
+
         return new CustomUserDetails(member, oAuth2User.getAttributes());
     }
 
@@ -57,9 +60,14 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
 
         // Step 2: 이메일로 기존 계정 확인 (다른 소셜 or 이메일 계정 → 자동 연동)
-        Optional<Member> existingMember = memberRepository
-                .findByEmailAndIsDeletedFalse(new MemberEmail(attributes.getEmail()))
-                .stream().findFirst();
+        // placeholder 이메일(kakao_xxx@kakao.social)은 실제 이메일이 아니므로 연동 스킵
+        boolean isPlaceholderEmail = attributes.getEmail() != null
+                && attributes.getEmail().endsWith("@kakao.social");
+
+        Optional<Member> existingMember = isPlaceholderEmail
+                ? Optional.empty()
+                : memberRepository.findByEmailAndIsDeletedFalse(new MemberEmail(attributes.getEmail()))
+                        .stream().findFirst();
 
         if (existingMember.isPresent()) {
             Member member = existingMember.get();

--- a/src/main/java/com/retrip/auth/application/in/MemberService.java
+++ b/src/main/java/com/retrip/auth/application/in/MemberService.java
@@ -22,6 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -38,6 +39,20 @@ public class MemberService implements ManageMemberUseCase {
 
     @Override
     public MemberCreateResponse createUser(MemberCreateRequest request) {
+        if (!request.termsAgreed()) {
+            throw new BusinessException(ErrorCode.TERMS_NOT_AGREED);
+        }
+
+        if (request.birthDate() != null) {
+            LocalDate birth = LocalDate.parse(request.birthDate());
+            if (birth.isAfter(LocalDate.now())) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+            if (birth.isBefore(LocalDate.now().minusYears(100))) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
+
         String encode = passwordEncoder.encode(request.password());
 
         List<Member> existingMembers = memberRepository.findByEmail(new MemberEmail(request.email()));

--- a/src/main/java/com/retrip/auth/application/in/MemberService.java
+++ b/src/main/java/com/retrip/auth/application/in/MemberService.java
@@ -1,5 +1,6 @@
 package com.retrip.auth.application.in;
 
+import com.retrip.auth.application.config.CustomUserDetails;
 import com.retrip.auth.application.config.JwtProvider;
 import com.retrip.auth.application.in.request.*;
 import com.retrip.auth.application.in.response.*;
@@ -17,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,29 +40,19 @@ public class MemberService implements ManageMemberUseCase {
     public MemberCreateResponse createUser(MemberCreateRequest request) {
         String encode = passwordEncoder.encode(request.password());
 
-        // 이메일 중복 체크 (탈퇴 회원 포함)
         List<Member> existingMembers = memberRepository.findByEmail(new MemberEmail(request.email()));
-
         if (!existingMembers.isEmpty()) {
             Member existing = existingMembers.get(0);
-            if (existing.getIsDeleted()) {
-                throw new BusinessException(ErrorCode.DELETED_MEMBER_CANNOT_REJOIN);
-            }
+            if (existing.getIsDeleted()) throw new BusinessException(ErrorCode.DELETED_MEMBER_CANNOT_REJOIN);
             throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
         Member member = memberRepository.save(request.to(encode));
 
-        // 토큰 생성
         Authentication authentication = createAuthentication(member);
         LoginResponse.TokenResponse tokens = jwtProvider.generateTokens(authentication);
 
-        // Refresh Token 저장
-        RefreshToken refreshToken = new RefreshToken(
-                tokens.refreshToken(),
-                member.getId().toString(),
-                "ROLE_USER"
-        );
+        RefreshToken refreshToken = new RefreshToken(tokens.refreshToken(), member.getId().toString(), "ROLE_USER");
         refreshTokenRepository.save(refreshToken);
 
         return MemberCreateResponse.of(member, tokens.accessToken(), tokens.refreshToken());
@@ -70,27 +60,27 @@ public class MemberService implements ManageMemberUseCase {
 
     @Override
     public MemberUpdateResponse updateUser(UUID memberId, MemberUpdateRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
-        // 현재 비밀번호 확인
-        if (!passwordEncoder.matches(request.password(), member.getPassword().getValue())) {
-            throw new BadCredentialsException("현재 비밀번호가 일치하지 않습니다.");
+        // 본인인증 완료 후 이름/생년월일 변경 불가
+        if (member.isVerified()) {
+            boolean tryName = request.name() != null && !request.name().equals(member.getNameValue());
+            boolean tryBirth = request.birthDate() != null && !request.birthDate().equals(member.getBirthDate());
+            if (tryName || tryBirth) throw new BusinessException(ErrorCode.VERIFIED_MEMBER_CANNOT_CHANGE);
         }
 
-        // 정보 수정
+        // 비밀번호 있는 계정만 현재 비밀번호 검증
+        if (member.hasPassword()) {
+            if (!passwordEncoder.matches(request.password(), member.getPasswordValue()))
+                throw new BadCredentialsException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
         String encodedNewPassword = request.newPassword() != null
                 ? passwordEncoder.encode(request.newPassword())
-                : member.getPassword().getValue();
+                : member.getPasswordValue();
 
-        member.update(
-                request.name(),
-                encodedNewPassword,
-                request.gender(),
-                request.birthDate()
-        );
+        member.update(request.name(), encodedNewPassword, request.gender(), request.birthDate());
 
-        // Access Token 재발급
         Authentication authentication = createAuthentication(member);
         LoginResponse.TokenResponse tokens = jwtProvider.generateTokens(authentication);
 
@@ -99,70 +89,61 @@ public class MemberService implements ManageMemberUseCase {
 
     @Override
     public void deleteUser(UUID memberId, MemberDeleteRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
-        // 현재 비밀번호 확인
-        if (!passwordEncoder.matches(request.password(), member.getPassword().getValue())) {
-            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        // 비밀번호 있는 계정만 비밀번호 검증
+        if (member.hasPassword()) {
+            if (!passwordEncoder.matches(request.password(), member.getPasswordValue()))
+                throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
 
-        // Refresh Token 삭제
         refreshTokenRepository.deleteByMemberId(memberId.toString());
         member.delete();
     }
 
     @Override
     public ChangePasswordResponse changePassword(UUID memberId, ChangePasswordRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
-        // 현재 비밀번호 확인
-        if (!passwordEncoder.matches(request.currentPassword(), member.getPassword().getValue())) {
+        // 소셜 전용 계정(비밀번호 없음) 차단
+        if (!member.hasPassword()) throw new BusinessException(ErrorCode.SOCIAL_MEMBER_CANNOT_CHANGE_PASSWORD);
+
+        if (!passwordEncoder.matches(request.currentPassword(), member.getPasswordValue()))
             throw new BadCredentialsException("현재 비밀번호가 일치하지 않습니다.");
-        }
 
-        // 새 비밀번호로 변경
         String encodedNewPassword = passwordEncoder.encode(request.newPassword());
         member.updatePassword(encodedNewPassword);
 
-        // 기존 Refresh Token 모두 삭제
         refreshTokenRepository.deleteByMemberId(memberId.toString());
 
-        // 새 토큰 발급
         Authentication authentication = createAuthentication(member);
         LoginResponse.TokenResponse tokens = jwtProvider.generateTokens(authentication);
 
-        // 새 Refresh Token 저장
-        RefreshToken refreshToken = new RefreshToken(
-                tokens.refreshToken(),
-                memberId.toString(),
-                "ROLE_USER"
-        );
+        RefreshToken refreshToken = new RefreshToken(tokens.refreshToken(), memberId.toString(), "ROLE_USER");
         refreshTokenRepository.save(refreshToken);
 
         return new ChangePasswordResponse(tokens.accessToken(), tokens.refreshToken());
     }
 
     @Override
+    public void setInitialPassword(UUID memberId, String rawPassword) {
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        member.setPassword(passwordEncoder.encode(rawPassword));
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public MemberInfoResponse getMyInfo(UUID memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         return MemberInfoResponse.of(member);
     }
 
     @Override
     @Transactional(readOnly = true)
     public VerifyPasswordResponse verifyPassword(UUID memberId, VerifyPasswordRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
-
-        boolean isValid = passwordEncoder.matches(
-                request.password(),
-                member.getPassword().getValue()
-        );
-
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        boolean isValid = member.hasPassword() &&
+                passwordEncoder.matches(request.password(), member.getPasswordValue());
         return new VerifyPasswordResponse(isValid);
     }
 
@@ -178,9 +159,7 @@ public class MemberService implements ManageMemberUseCase {
     @Override
     @Transactional(readOnly = true)
     public List<MemberSearchResponse> getMembersByIds(List<UUID> ids) {
-        if (ids == null || ids.isEmpty()) {
-            return List.of();
-        }
+        if (ids == null || ids.isEmpty()) return List.of();
         return memberRepository.findAllByIdInAndIsDeletedFalse(ids)
                 .stream()
                 .map(MemberSearchResponse::of)
@@ -191,33 +170,13 @@ public class MemberService implements ManageMemberUseCase {
     @Transactional(readOnly = true)
     public UUID findIdByEmail(String email) {
         return memberRepository.findByEmailAndIsDeletedFalse(new MemberEmail(email))
-                .stream()
-                .findFirst()
+                .stream().findFirst()
                 .map(Member::getId)
                 .orElseThrow(MemberNotFoundException::new);
     }
 
-    // ========================================
-    // Private Helper Methods
-    // ========================================
-
-    private Member findByEmail(String email) {
-        return memberRepository.findByEmailAndIsDeletedFalse(new MemberEmail(email))
-                .stream().findAny().orElseThrow(MemberNotFoundException::new);
-    }
-
-    private boolean isSamePassword(String password, String inputPassword) {
-        if (!passwordEncoder.matches(inputPassword, password)) {
-            throw new BadCredentialsException("Bad credentials");
-        }
-        return true;
-    }
-
     private Authentication createAuthentication(Member member) {
-        return new UsernamePasswordAuthenticationToken(
-                member.getId().toString(),  // ✅ email → memberId로 변경
-                null,
-                List.of(new SimpleGrantedAuthority("ROLE_USER"))
-        );
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/retrip/auth/application/in/MemberService.java
+++ b/src/main/java/com/retrip/auth/application/in/MemberService.java
@@ -176,6 +176,8 @@ public class MemberService implements ManageMemberUseCase {
     }
 
     private Authentication createAuthentication(Member member) {
+        // Hibernate 세션 내에서 authorities 강제 초기화 (LazyInitializationException 방지)
+        member.getAuthorities().getValues().size();
         CustomUserDetails userDetails = new CustomUserDetails(member);
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }

--- a/src/main/java/com/retrip/auth/application/in/OAuthAttributes.java
+++ b/src/main/java/com/retrip/auth/application/in/OAuthAttributes.java
@@ -3,6 +3,7 @@ package com.retrip.auth.application.in;
 import com.retrip.auth.domain.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 
 import java.util.Map;
 
@@ -37,9 +38,12 @@ public class OAuthAttributes {
                 .build();
     }
 
+    @SuppressWarnings("unchecked")
     private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        if (kakaoAccount == null) throw new OAuth2AuthenticationException("카카오 계정 정보를 가져올 수 없습니다.");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        if (profile == null) throw new OAuth2AuthenticationException("카카오 프로필 정보를 가져올 수 없습니다.");
 
         return OAuthAttributes.builder()
                 .name((String) profile.get("nickname"))
@@ -67,6 +71,6 @@ public class OAuthAttributes {
 
 
     public Member toEntity() {
-        return Member.createSocialMember(name, email, provider, providerId);
+        return Member.createSocialMember(name, email, provider);
     }
 }

--- a/src/main/java/com/retrip/auth/application/in/OAuthAttributes.java
+++ b/src/main/java/com/retrip/auth/application/in/OAuthAttributes.java
@@ -45,9 +45,16 @@ public class OAuthAttributes {
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
         if (profile == null) throw new OAuth2AuthenticationException("카카오 프로필 정보를 가져올 수 없습니다.");
 
+        String email = (String) kakaoAccount.get("email");
+        if (email == null) {
+            // 비즈앱 미인증 시 이메일 제공 불가 → providerId 기반 placeholder 사용
+            // 계정 연동 테스트 시: 이 이메일로 일반 회원가입 후 카카오 로그인하면 연동됨
+            email = "kakao_" + attributes.get(userNameAttributeName) + "@kakao.social";
+        }
+
         return OAuthAttributes.builder()
                 .name((String) profile.get("nickname"))
-                .email((String) kakaoAccount.get("email"))
+                .email(email)
                 .provider("kakao")
                 .providerId(String.valueOf(attributes.get(userNameAttributeName)))
                 .attributes(attributes)

--- a/src/main/java/com/retrip/auth/application/in/request/ChangePasswordRequest.java
+++ b/src/main/java/com/retrip/auth/application/in/request/ChangePasswordRequest.java
@@ -1,6 +1,13 @@
 package com.retrip.auth.application.in.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public record ChangePasswordRequest(
+        @NotBlank(message = "현재 비밀번호는 필수입니다.")
         String currentPassword,
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]|;:,./]).{8,20}$",
+                 message = "비밀번호는 영문·숫자·특수문자 포함 8~20자여야 합니다.")
         String newPassword
 ) {}

--- a/src/main/java/com/retrip/auth/application/in/request/MemberCreateRequest.java
+++ b/src/main/java/com/retrip/auth/application/in/request/MemberCreateRequest.java
@@ -2,17 +2,28 @@ package com.retrip.auth.application.in.request;
 
 import com.retrip.auth.domain.entity.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 @Schema(description = "Member 회원가입 Request")
 public record MemberCreateRequest(
         @Schema(description = "이메일")
+        @NotBlank @Email(message = "올바른 이메일 형식을 입력해주세요.")
         String email,
         @Schema(description = "비밀번호")
+        @NotBlank
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]|;:,./]).{8,20}$",
+                 message = "비밀번호는 영문·숫자·특수문자 포함 8~20자여야 합니다.")
         String password,
         @Schema(description = "사용자 이름")
         String name,
+        @Schema(description = "닉네임 (선택, 미입력 시 이름으로 자동 설정)")
+        @Size(max = 15, message = "닉네임은 최대 15자까지 입력할 수 있습니다.")
+        String nickname,
         @Schema(description = "성별 (M/F)")
         String gender,
         @Schema(description = "생년월일 (YYYY-MM-DD)")
@@ -31,7 +42,8 @@ public record MemberCreateRequest(
                 gender,
                 birthDate,
                 termsAgreed,
-                marketingAgreed
+                marketingAgreed,
+                nickname
         );
     }
 }

--- a/src/main/java/com/retrip/auth/application/in/request/MemberCreateRequest.java
+++ b/src/main/java/com/retrip/auth/application/in/request/MemberCreateRequest.java
@@ -20,13 +20,21 @@ public record MemberCreateRequest(
                  message = "비밀번호는 영문·숫자·특수문자 포함 8~20자여야 합니다.")
         String password,
         @Schema(description = "사용자 이름")
+        @NotBlank(message = "이름은 필수입니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z ]+$", message = "이름에는 숫자나 특수문자를 포함할 수 없습니다.")
+        @Size(max = 10, message = "이름은 최대 10자까지 입력할 수 있습니다.")
         String name,
         @Schema(description = "닉네임 (선택, 미입력 시 이름으로 자동 설정)")
         @Size(max = 15, message = "닉네임은 최대 15자까지 입력할 수 있습니다.")
         String nickname,
         @Schema(description = "성별 (M/F)")
+        @NotBlank(message = "성별은 필수입니다.")
+        @Pattern(regexp = "^[MF]$", message = "성별은 M 또는 F여야 합니다.")
         String gender,
         @Schema(description = "생년월일 (YYYY-MM-DD)")
+        @NotBlank(message = "생년월일은 필수입니다.")
+        @Pattern(regexp = "^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$",
+                 message = "생년월일은 YYYY-MM-DD 형식이어야 합니다.")
         String birthDate,
         @Schema(description = "필수 약관 동의")
         boolean termsAgreed,

--- a/src/main/java/com/retrip/auth/application/in/request/SetInitialPasswordRequest.java
+++ b/src/main/java/com/retrip/auth/application/in/request/SetInitialPasswordRequest.java
@@ -1,0 +1,15 @@
+package com.retrip.auth.application.in.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "소셜 유저 최초 비밀번호 설정 Request")
+public record SetInitialPasswordRequest(
+        @Schema(description = "설정할 비밀번호")
+        @NotBlank
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]|;:,./]).{8,20}$",
+                 message = "비밀번호는 영문·숫자·특수문자 포함 8~20자여야 합니다.")
+        String password
+) {
+}

--- a/src/main/java/com/retrip/auth/application/in/response/MemberInfoResponse.java
+++ b/src/main/java/com/retrip/auth/application/in/response/MemberInfoResponse.java
@@ -1,7 +1,7 @@
-
 package com.retrip.auth.application.in.response;
 
 import com.retrip.auth.domain.entity.Member;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -9,13 +9,21 @@ public record MemberInfoResponse(
         UUID id,
         String email,
         String name,
+        String nickname,
+        boolean isVerified,
+        boolean hasPassword,
+        String lastLoginProvider,
         LocalDateTime createdAt
 ) {
     public static MemberInfoResponse of(Member member) {
         return new MemberInfoResponse(
                 member.getId(),
-                member.getEmail().getValue(),
-                member.getName().getValue(),
+                member.getEmailValue(),
+                member.getNameValue(),
+                member.getNickname(),
+                member.isVerified(),
+                member.hasPassword(),
+                member.getProvider(),
                 member.getCreatedAt()
         );
     }

--- a/src/main/java/com/retrip/auth/application/in/usercase/ManageMemberUseCase.java
+++ b/src/main/java/com/retrip/auth/application/in/usercase/ManageMemberUseCase.java
@@ -21,4 +21,6 @@ public interface ManageMemberUseCase {
     List<MemberSearchResponse> searchMembers(String name);
 
     List<MemberSearchResponse> getMembersByIds(List<UUID> ids);
+
+    void setInitialPassword(UUID memberId, String rawPassword);
 }

--- a/src/main/java/com/retrip/auth/application/out/repository/MemberSocialProviderRepository.java
+++ b/src/main/java/com/retrip/auth/application/out/repository/MemberSocialProviderRepository.java
@@ -1,0 +1,14 @@
+package com.retrip.auth.application.out.repository;
+
+import com.retrip.auth.domain.entity.MemberSocialProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MemberSocialProviderRepository extends JpaRepository<MemberSocialProvider, Long> {
+    List<MemberSocialProvider> findByMemberId(UUID memberId);
+    Optional<MemberSocialProvider> findByProviderAndProviderId(String provider, String providerId);
+    boolean existsByMemberIdAndProvider(UUID memberId, String provider);
+}

--- a/src/main/java/com/retrip/auth/application/service/ProfileService.java
+++ b/src/main/java/com/retrip/auth/application/service/ProfileService.java
@@ -4,9 +4,11 @@ import com.retrip.auth.application.dto.request.UpdateNotificationRequest;
 import com.retrip.auth.application.dto.request.UpdateProfileRequest;
 import com.retrip.auth.application.dto.response.ProfileResponse;
 import com.retrip.auth.application.out.repository.MemberRepository;
+import com.retrip.auth.application.out.repository.MemberSocialProviderRepository;
 import com.retrip.auth.application.out.repository.MemberTravelStyleRepository;
 import com.retrip.auth.application.out.repository.TravelStyleRepository;
 import com.retrip.auth.domain.entity.Member;
+import com.retrip.auth.domain.entity.MemberSocialProvider;
 import com.retrip.auth.domain.entity.MemberTravelStyle;
 import com.retrip.auth.domain.entity.TravelStyle;
 import com.retrip.auth.domain.exception.MemberNotFoundException;
@@ -29,8 +31,8 @@ public class ProfileService {
     private final MemberRepository memberRepository;
     private final TravelStyleRepository travelStyleRepository;
     private final MemberTravelStyleRepository memberTravelStyleRepository;
+    private final MemberSocialProviderRepository socialProviderRepository;
 
-    // [수정] String email -> String memberId (UUID)
     public ProfileResponse getProfile(String memberId) {
         Member member = memberRepository.findById(UUID.fromString(memberId))
                 .orElseThrow(MemberNotFoundException::new);
@@ -40,15 +42,17 @@ public class ProfileService {
                 .map(mts -> mts.getTravelStyle().getName())
                 .collect(Collectors.toList());
 
-        return ProfileResponse.from(member, travelStyles);
+        List<MemberSocialProvider> socialProviders = socialProviderRepository.findByMemberId(member.getId());
+
+        return ProfileResponse.from(member, travelStyles, socialProviders);
     }
 
-    // [수정] String email -> String memberId (UUID)
     @Transactional
     public ProfileResponse updateProfile(String memberId, UpdateProfileRequest request) {
         Member member = memberRepository.findById(UUID.fromString(memberId))
                 .orElseThrow(MemberNotFoundException::new);
 
+        if (request.getNickname() != null) member.updateNickname(request.getNickname());
         member.updateProfile(request.getBio(), request.getMbti(), request.getProfileImageUrl());
 
         if (request.getTravelStyles() != null) {
@@ -60,15 +64,15 @@ public class ProfileService {
                 .map(mts -> mts.getTravelStyle().getName())
                 .collect(Collectors.toList());
 
-        return ProfileResponse.from(member, travelStyles);
+        List<MemberSocialProvider> socialProviders = socialProviderRepository.findByMemberId(member.getId());
+
+        return ProfileResponse.from(member, travelStyles, socialProviders);
     }
 
-    // [수정] String email -> String memberId (UUID)
     @Transactional
     public void updateNotificationSettings(String memberId, UpdateNotificationRequest request) {
         Member member = memberRepository.findById(UUID.fromString(memberId))
                 .orElseThrow(MemberNotFoundException::new);
-
         member.updateNotificationSettings(request.getEnabled());
     }
 

--- a/src/main/java/com/retrip/auth/domain/entity/Member.java
+++ b/src/main/java/com/retrip/auth/domain/entity/Member.java
@@ -1,5 +1,7 @@
 package com.retrip.auth.domain.entity;
 
+import com.retrip.auth.domain.exception.common.BusinessException;
+import com.retrip.auth.domain.exception.common.ErrorCode;
 import com.retrip.auth.domain.vo.MemberEmail;
 import com.retrip.auth.domain.vo.MemberName;
 import com.retrip.auth.domain.vo.MemberPassword;
@@ -40,9 +42,6 @@ public class Member extends BaseEntity {
     @Column(length = 20)
     private String provider;
 
-    @Column(unique = true)
-    private String providerId;
-
     // 본인인증 관련
     @Column(length = 88, unique = true)
     private String ci;
@@ -82,6 +81,9 @@ public class Member extends BaseEntity {
     @Column(length = 4)
     private String mbti;
 
+    @Column(length = 15)
+    private String nickname;
+
     // 설정
     @Column(nullable = false)
     @Builder.Default
@@ -99,7 +101,9 @@ public class Member extends BaseEntity {
         return this.name != null ? this.name.getValue() : null;
     }
 
-    public static Member create(String name, String email, String password, List<String> authorities, String gender, String birthDate, boolean termsAgreed, boolean marketingAgreed) {
+    public static Member create(String name, String email, String password, List<String> authorities,
+                                String gender, String birthDate, boolean termsAgreed, boolean marketingAgreed,
+                                String nickname) {
         Member member = Member.builder()
                 .id(UUID.randomUUID())
                 .name(new MemberName(name))
@@ -112,12 +116,13 @@ public class Member extends BaseEntity {
                 .birthDate(birthDate)
                 .termsAgreed(termsAgreed)
                 .marketingAgreed(marketingAgreed)
+                .nickname((nickname != null && !nickname.isBlank()) ? nickname : name)
                 .build();
         member.authorities = new Authorities(authorities, member);
         return member;
     }
 
-    public static Member createSocialMember(String name, String email, String provider, String providerId) {
+    public static Member createSocialMember(String name, String email, String provider) {
         Member member = Member.builder()
                 .id(UUID.randomUUID())
                 .name(new MemberName(name))
@@ -125,7 +130,7 @@ public class Member extends BaseEntity {
                 .isDeleted(false)
                 .password(new MemberPassword(null))
                 .provider(provider)
-                .providerId(providerId)
+                .nickname(name)
                 .isVerified(false)
                 .build();
         member.authorities = new Authorities(List.of("user"), member);
@@ -159,8 +164,26 @@ public class Member extends BaseEntity {
         this.verifiedAt = LocalDateTime.now();
     }
 
-    public void updateSocialInfo(String name) {
+    public void updateSocialInfo(String name, String provider) {
         this.name = new MemberName(name);
+        this.provider = provider;
+    }
+
+    public void updateLastLoginProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public boolean hasPassword() {
+        return this.getPasswordValue() != null;
+    }
+
+    public void setPassword(String encodedPassword) {
+        if (this.hasPassword()) throw new BusinessException(ErrorCode.PASSWORD_ALREADY_EXISTS);
+        this.password = new MemberPassword(encodedPassword);
     }
 
     public void updatePassword(String encodedPassword) {

--- a/src/main/java/com/retrip/auth/domain/entity/MemberSocialProvider.java
+++ b/src/main/java/com/retrip/auth/domain/entity/MemberSocialProvider.java
@@ -1,0 +1,49 @@
+package com.retrip.auth.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "member_social_provider",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_member_provider", columnNames = {"member_id", "provider"}),
+                @UniqueConstraint(name = "uk_provider_provider_id", columnNames = {"provider", "provider_id"})
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberSocialProvider {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false, columnDefinition = "varbinary(16)")
+    private UUID memberId;
+
+    @Column(length = 20, nullable = false)
+    private String provider;        // "kakao" | "naver" | "google"
+
+    @Column(name = "provider_id", length = 255, nullable = false)
+    private String providerId;      // 소셜 서비스의 유저 고유 ID
+
+    @Column(length = 50)
+    private String email;           // 해당 소셜 계정의 이메일
+
+    @Column(name = "linked_at", nullable = false)
+    private LocalDateTime linkedAt;
+
+    public static MemberSocialProvider create(UUID memberId, String provider, String providerId, String email) {
+        MemberSocialProvider msp = new MemberSocialProvider();
+        msp.memberId = memberId;
+        msp.provider = provider;
+        msp.providerId = providerId;
+        msp.email = email;
+        msp.linkedAt = LocalDateTime.now();
+        return msp;
+    }
+}

--- a/src/main/java/com/retrip/auth/domain/exception/common/ErrorCode.java
+++ b/src/main/java/com/retrip/auth/domain/exception/common/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     DELETED_MEMBER_CANNOT_REJOIN(HttpStatus.BAD_REQUEST, "Member-003", "탈퇴한 이메일은 재가입할 수 없습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "Member-004", "이미 존재하는 이메일입니다."),
     DUPLICATE_USER(HttpStatus.CONFLICT, "Member-005", "이미 가입된 정보입니다."),
+    VERIFIED_MEMBER_CANNOT_CHANGE(HttpStatus.BAD_REQUEST, "Member-006", "본인인증 완료 후 이름/생년월일은 변경할 수 없습니다."),
+    SOCIAL_MEMBER_CANNOT_CHANGE_PASSWORD(HttpStatus.FORBIDDEN, "Member-007", "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
+    PASSWORD_ALREADY_EXISTS(HttpStatus.CONFLICT, "Member-008", "이미 비밀번호가 설정된 계정입니다."),
 
     EXTENSION_NOT_FOUND(BAD_REQUEST, "Image-001", "지원하지 않는 이미지 확장자입니다."),
     ;

--- a/src/main/java/com/retrip/auth/domain/exception/common/ErrorCode.java
+++ b/src/main/java/com/retrip/auth/domain/exception/common/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     VERIFIED_MEMBER_CANNOT_CHANGE(HttpStatus.BAD_REQUEST, "Member-006", "본인인증 완료 후 이름/생년월일은 변경할 수 없습니다."),
     SOCIAL_MEMBER_CANNOT_CHANGE_PASSWORD(HttpStatus.FORBIDDEN, "Member-007", "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
     PASSWORD_ALREADY_EXISTS(HttpStatus.CONFLICT, "Member-008", "이미 비밀번호가 설정된 계정입니다."),
+    TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "Member-009", "필수 약관에 동의해야 합니다."),
 
     EXTENSION_NOT_FOUND(BAD_REQUEST, "Image-001", "지원하지 않는 이미지 확장자입니다."),
     ;

--- a/src/main/java/com/retrip/auth/domain/vo/MemberEmail.java
+++ b/src/main/java/com/retrip/auth/domain/vo/MemberEmail.java
@@ -19,8 +19,9 @@ public class MemberEmail {
     private String value;
 
     public MemberEmail(String value) {
-        validate(value);
-        this.value = value;
+        String trimmed = value.trim();
+        validate(trimmed);
+        this.value = trimmed;
     }
 
     private void validate(String value) {

--- a/src/main/java/com/retrip/auth/domain/vo/MemberName.java
+++ b/src/main/java/com/retrip/auth/domain/vo/MemberName.java
@@ -23,9 +23,17 @@ public class MemberName {
         this.value = value;
     }
 
+    private static final String NAME_PATTERN = "^[가-힣a-zA-Z ]+$";
+
     private void validate(String value) {
+        if (value.isBlank()) {
+            throw new InvalidValueException("유저 이름은 공백일 수 없습니다.");
+        }
         if (value.length() > NAME_LENGTH_LIMIT) {
             throw new InvalidValueException("유저 이름은 " + NAME_LENGTH_LIMIT + "자를 넘을 수 없습니다.");
+        }
+        if (!value.matches(NAME_PATTERN)) {
+            throw new InvalidValueException("유저 이름에는 숫자나 특수문자를 포함할 수 없습니다.");
         }
     }
 

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/AuthController.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/AuthController.java
@@ -6,6 +6,7 @@ import com.retrip.auth.domain.exception.common.InvalidValueException;
 import com.retrip.auth.infra.adapter.in.rest.common.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +16,9 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+
+    @Value("${app.cookie.secure:true}")
+    private boolean cookieSecure;
 
     @PostMapping("/reissue")
     public ApiResponse<LoginResponse.TokenResponse> reissue(
@@ -29,10 +33,10 @@ public class AuthController {
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenResponse.refreshToken())
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieSecure)
                 .path("/")
                 .maxAge(14 * 24 * 60 * 60) // 14일
-                .sameSite("None")
+                .sameSite(cookieSecure ? "None" : "Lax")
                 .build();
         response.addHeader("Set-Cookie", cookie.toString());
 
@@ -51,10 +55,10 @@ public class AuthController {
         // 쿠키 삭제 (만료시간 0)
         ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true)
-                .secure(true)
+                .secure(cookieSecure)
                 .path("/")
                 .maxAge(0)
-                .sameSite("None")
+                .sameSite(cookieSecure ? "None" : "Lax")
                 .build();
         response.addHeader("Set-Cookie", cookie.toString());
 

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/controller/ProfileController.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/controller/ProfileController.java
@@ -31,8 +31,8 @@ public class ProfileController {
     public ApiResponse<ProfileResponse> getMyProfile(
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        String email = userDetails.getUsername();
-        ProfileResponse profile = profileService.getProfile(email);
+        String memberId = userDetails.getUsername();
+        ProfileResponse profile = profileService.getProfile(memberId);
         return ApiResponse.ok(profile);
     }
 
@@ -44,8 +44,8 @@ public class ProfileController {
             @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody UpdateProfileRequest request
     ) {
-        String email = userDetails.getUsername();
-        ProfileResponse profile = profileService.updateProfile(email, request);
+        String memberId = userDetails.getUsername();
+        ProfileResponse profile = profileService.updateProfile(memberId, request);
         return ApiResponse.ok(profile);
     }
 
@@ -57,8 +57,8 @@ public class ProfileController {
             @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody UpdateNotificationRequest request
     ) {
-        String email = userDetails.getUsername();
-        profileService.updateNotificationSettings(email, request);
+        String memberId = userDetails.getUsername();
+        profileService.updateNotificationSettings(memberId, request);
         return ApiResponse.ok(null);
     }
 
@@ -70,10 +70,10 @@ public class ProfileController {
             @AuthenticationPrincipal UserDetails userDetails,
             @Valid @RequestBody VerifyIdentityRequest request
     ) {
-        String email = userDetails.getUsername();
+        String memberId = userDetails.getUsername();
         VerifyIdentityResponse response = identityVerificationService.verifyAndSave(
                 request.getImpUid(),
-                email
+                memberId
         );
         return ApiResponse.ok(response);
     }

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/filter/JwtAuthenticationFilter.java
@@ -111,7 +111,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.startsWith("/swagger-ui")
                 || path.startsWith("/v3/api-docs")
                 || path.startsWith("/swagger-resources")
-                || path.startsWith("/webjars")
-                || path.startsWith("/debug");
+                || path.startsWith("/webjars");
     }
 }

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/filter/LoginAuthenticationFilter.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/filter/LoginAuthenticationFilter.java
@@ -1,10 +1,12 @@
 package com.retrip.auth.infra.adapter.in.rest.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.retrip.auth.application.config.CustomUserDetails;
 import com.retrip.auth.application.config.JwtConfig;
 import com.retrip.auth.application.config.JwtProvider;
 import com.retrip.auth.application.in.request.LoginRequest;
 import com.retrip.auth.application.in.response.LoginResponse;
+import com.retrip.auth.application.out.repository.MemberRepository;
 import com.retrip.auth.application.out.repository.RefreshTokenRepository;
 import com.retrip.auth.domain.entity.RefreshToken;
 import com.retrip.auth.infra.adapter.in.rest.common.ApiResponse;
@@ -23,17 +25,19 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
 
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberRepository memberRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public LoginAuthenticationFilter(JwtConfig jwtConfig,
                                      AuthenticationManager authenticationManager,
                                      JwtProvider jwtProvider,
-                                     RefreshTokenRepository refreshTokenRepository) {
+                                     RefreshTokenRepository refreshTokenRepository,
+                                     MemberRepository memberRepository) {
         super.setAuthenticationManager(authenticationManager);
-
         this.jwtProvider = jwtProvider;
         this.refreshTokenRepository = refreshTokenRepository;
-        setFilterProcessesUrl("/login"); // POST /login 요청을 가로채도록 설정
+        this.memberRepository = memberRepository;
+        setFilterProcessesUrl("/login");
     }
 
     // 1. 로그인 시도
@@ -41,13 +45,10 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
         try {
             LoginRequest loginRequest = objectMapper.readValue(request.getInputStream(), LoginRequest.class);
-
             UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                     loginRequest.id(),
                     loginRequest.password()
             );
-
-            // ★ [수정] 부모 클래스의 메서드를 통해 매니저를 호출
             return this.getAuthenticationManager().authenticate(authToken);
         } catch (IOException e) {
             throw new RuntimeException("로그인 요청 파싱 실패", e);
@@ -58,9 +59,15 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
 
-        LoginResponse.TokenResponse tokenResponse = jwtProvider.generateTokens(authResult);
+        // 마지막 로그인 방식 업데이트
+        if (authResult.getPrincipal() instanceof CustomUserDetails userDetails) {
+            memberRepository.findById(userDetails.getMember().getId()).ifPresent(member -> {
+                member.updateLastLoginProvider("local");
+                memberRepository.save(member);
+            });
+        }
 
-        // CustomUserDetails.getName()은 UUID String을 반환하도록 설정했으므로 바로 사용 가능
+        LoginResponse.TokenResponse tokenResponse = jwtProvider.generateTokens(authResult);
         String memberId = authResult.getName();
 
         RefreshToken refreshToken = new RefreshToken(

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/filter/LoginAuthenticationFilter.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/filter/LoginAuthenticationFilter.java
@@ -19,6 +19,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import org.springframework.http.ResponseCookie;
+
 import java.io.IOException;
 
 public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
@@ -27,16 +29,19 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
     private final RefreshTokenRepository refreshTokenRepository;
     private final MemberRepository memberRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final boolean cookieSecure;
 
     public LoginAuthenticationFilter(JwtConfig jwtConfig,
                                      AuthenticationManager authenticationManager,
                                      JwtProvider jwtProvider,
                                      RefreshTokenRepository refreshTokenRepository,
-                                     MemberRepository memberRepository) {
+                                     MemberRepository memberRepository,
+                                     boolean cookieSecure) {
         super.setAuthenticationManager(authenticationManager);
         this.jwtProvider = jwtProvider;
         this.refreshTokenRepository = refreshTokenRepository;
         this.memberRepository = memberRepository;
+        this.cookieSecure = cookieSecure;
         setFilterProcessesUrl("/login");
     }
 
@@ -76,6 +81,16 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
                 "ROLE_USER"
         );
         refreshTokenRepository.save(refreshToken);
+
+        // refreshToken을 HttpOnly 쿠키로 설정
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenResponse.refreshToken())
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/")
+                .maxAge(14 * 24 * 60 * 60)
+                .sameSite(cookieSecure ? "None" : "Lax")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/in/MemberController.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/in/MemberController.java
@@ -80,14 +80,7 @@ public class MemberController {
     @GetMapping("/me")
     @Schema(description = "내 정보 조회")
     public ApiResponse<MemberInfoResponse> getMyInfo(Authentication authentication) {
-        log.info("=== Controller /users/me ===");
-        log.info("Authentication: {}", authentication);
-        log.info("Principal: {}", authentication != null ? authentication.getPrincipal() : "null");
-        log.info("Authorities: {}", authentication != null ? authentication.getAuthorities() : "null");
-
         UUID memberId = extractMemberId(authentication);
-        log.info("Extracted Member ID: {}", memberId);
-
         return ApiResponse.ok(manageMemberUseCase.getMyInfo(memberId));
     }
 

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/in/MemberController.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/in/MemberController.java
@@ -1,6 +1,7 @@
 package com.retrip.auth.infra.adapter.in.rest.in;
 
 import com.retrip.auth.application.in.request.*;
+import com.retrip.auth.application.in.request.SetInitialPasswordRequest;
 import com.retrip.auth.application.in.response.*;
 import com.retrip.auth.application.in.response.MemberSearchResponse;
 import com.retrip.auth.application.in.usercase.ManageMemberUseCase;
@@ -55,6 +56,16 @@ public class MemberController {
         manageMemberUseCase.deleteUser(memberId, request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .body(ApiResponse.noContent());
+    }
+
+    @PostMapping("/password")
+    @Schema(description = "소셜 유저 최초 비밀번호 설정")
+    public ResponseEntity<ApiResponse<?>> setInitialPassword(
+            Authentication authentication,
+            @RequestBody SetInitialPasswordRequest request) {
+        UUID memberId = extractMemberId(authentication);
+        manageMemberUseCase.setInitialPassword(memberId, request.password());
+        return ResponseEntity.ok(ApiResponse.noContent());
     }
 
     @PatchMapping("/password")

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/in/MemberController.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/in/MemberController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import jakarta.validation.Valid;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,7 +33,7 @@ public class MemberController {
     @PostMapping
     @Schema(description = "회원 가입")
     public ResponseEntity<ApiResponse<MemberCreateResponse>> createUser(
-            @RequestBody MemberCreateRequest request) {
+            @Valid @RequestBody MemberCreateRequest request) {
         MemberCreateResponse response = manageMemberUseCase.createUser(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(response));
@@ -72,7 +73,7 @@ public class MemberController {
     @Schema(description = "비밀번호 변경")
     public ApiResponse<ChangePasswordResponse> changePassword(
             Authentication authentication,
-            @RequestBody ChangePasswordRequest request) {
+            @Valid @RequestBody ChangePasswordRequest request) {
         UUID memberId = extractMemberId(authentication);
         return ApiResponse.ok(manageMemberUseCase.changePassword(memberId, request));
     }

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/in/TestController.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/in/TestController.java
@@ -65,7 +65,8 @@ public class TestController {
                             "M",
                             "1995-01-01",
                             true,  // termsAgreed
-                            true   // marketingAgreed
+                            true,  // marketingAgreed
+                            null   // nickname (이름으로 자동 설정)
                     );
                     
                     // 3. DB 저장

--- a/src/main/java/com/retrip/auth/infra/config/SwaggerConfig.java
+++ b/src/main/java/com/retrip/auth/infra/config/SwaggerConfig.java
@@ -48,10 +48,21 @@ public class SwaggerConfig {
                                         "- **이메일 로그인**: `POST /login` → Access Token 발급\n" +
                                         "- **소셜 로그인**: 브라우저에서 `GET /oauth2/authorization/{provider}` → 콜백 URL로 Token 전달\n" +
                                         "- **Refresh Token**: HttpOnly Cookie 방식 (자동 전송)\n\n" +
+                                        "## ⚠️ 프론트엔드 필수 설정\n" +
+                                        "### withCredentials 설정 (쿠키 전송)\n" +
+                                        "`/login` · `/auth/reissue` · `/auth/logout` 은 HttpOnly 쿠키(refreshToken)를 사용합니다.\n" +
+                                        "**크로스 오리진 환경에서 반드시 아래 설정이 필요합니다.**\n" +
+                                        "- axios: `withCredentials: true`\n" +
+                                        "- fetch: `credentials: 'include'`\n\n" +
+                                        "이 설정이 없으면 쿠키가 전송되지 않아 **토큰 재발급과 로그아웃이 동작하지 않습니다.**\n\n" +
+                                        "### refreshToken 저장 금지\n" +
+                                        "로그인 응답 body에 refreshToken이 포함되더라도 **localStorage/sessionStorage에 저장하지 마세요.**\n" +
+                                        "서버가 Set-Cookie로 자동 관리합니다. 프론트는 **accessToken만** 저장하세요.\n\n" +
                                         "## 주요 특이사항\n" +
                                         "- `/login` 요청 시 이메일 필드명은 `email`이 아닌 **`id`** 입니다.\n" +
                                         "- 소셜 전용 계정은 `hasPassword=false`. PATCH /users/password → 403, POST /users/password로 최초 설정 가능.\n" +
-                                        "- 본인인증 완료 후(`isVerified=true`) name/birthDate 변경 불가.")
+                                        "- 본인인증 완료 후(`isVerified=true`) name/birthDate 변경 불가.\n" +
+                                        "- `travelStyles` 필드는 ID가 아닌 **이름 문자열 배열**입니다. (예: `[\"계획철저\", \"사진광\"]`)")
                 )
                 .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
                 // Spring Security 필터 레벨 엔드포인트 수동 등록

--- a/src/main/java/com/retrip/auth/infra/config/SwaggerConfig.java
+++ b/src/main/java/com/retrip/auth/infra/config/SwaggerConfig.java
@@ -2,25 +2,166 @@ package com.retrip.auth.infra.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
-import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
+
     @Bean
     public OpenAPI springShopOpenAPI() {
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))
                 .components(
                         new Components()
-                ).info(
+                                .addSecuritySchemes("BearerAuth",
+                                        new SecurityScheme()
+                                                .type(SecurityScheme.Type.HTTP)
+                                                .scheme("bearer")
+                                                .bearerFormat("JWT")
+                                                .description("로그인/소셜 로그인 후 발급된 Access Token을 입력하세요. (Bearer 접두사 불필요)")
+                                )
+                )
+                .info(
                         new Info()
-                                .title("Auth Application")
+                                .title("ReTrip Auth API")
                                 .version("v0.0.1")
-                );
+                                .description("ReTrip 인증 서비스 API 명세\n\n" +
+                                        "## 인증 방식\n" +
+                                        "- **이메일 로그인**: `POST /login` → Access Token 발급\n" +
+                                        "- **소셜 로그인**: 브라우저에서 `GET /oauth2/authorization/{provider}` → 콜백 URL로 Token 전달\n" +
+                                        "- **Refresh Token**: HttpOnly Cookie 방식 (자동 전송)\n\n" +
+                                        "## 주요 특이사항\n" +
+                                        "- `/login` 요청 시 이메일 필드명은 `email`이 아닌 **`id`** 입니다.\n" +
+                                        "- 소셜 전용 계정은 `hasPassword=false`. PATCH /users/password → 403, POST /users/password로 최초 설정 가능.\n" +
+                                        "- 본인인증 완료 후(`isVerified=true`) name/birthDate 변경 불가.")
+                )
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                // Spring Security 필터 레벨 엔드포인트 수동 등록
+                .path("/login", loginPathItem())
+                .path("/oauth2/authorization/{provider}", oauthPathItem())
+                .path("/auth/reissue", reissuePathItem())
+                .path("/auth/logout", logoutPathItem());
+    }
+
+    private PathItem loginPathItem() {
+        Schema<?> requestSchema = new ObjectSchema()
+                .addProperty("id", new StringSchema()
+                        .example("user@example.com")
+                        .description("이메일 주소 (필드명 주의: email이 아닌 id)"))
+                .addProperty("password", new StringSchema()
+                        .example("Test1234!")
+                        .description("비밀번호"))
+                .required(List.of("id", "password"));
+
+        Schema<?> responseSchema = new ObjectSchema()
+                .addProperty("accessToken", new StringSchema().description("JWT Access Token (30분 유효)"))
+                .addProperty("tokenType", new StringSchema().example("Bearer"))
+                .addProperty("expiresIn", new Schema<Integer>().example(1800).description("만료 시간(초)"));
+
+        return new PathItem().post(
+                new Operation()
+                        .tags(List.of("인증 (Security Filter)"))
+                        .summary("이메일 로그인")
+                        .description(
+                                "Spring Security LoginAuthenticationFilter가 처리합니다. 컨트롤러 코드 없음.\n\n" +
+                                "**주의**: 요청 본문의 이메일 필드명이 `email`이 아닌 **`id`** 입니다.\n\n" +
+                                "성공 시 Response Body에 accessToken, Set-Cookie 헤더에 refreshToken(HttpOnly) 발급.")
+                        .requestBody(new RequestBody()
+                                .required(true)
+                                .content(new Content().addMediaType("application/json",
+                                        new MediaType().schema(requestSchema))))
+                        .responses(new ApiResponses()
+                                .addApiResponse("200", new ApiResponse()
+                                        .description("로그인 성공 — accessToken 반환 + Set-Cookie: refreshToken")
+                                        .content(new Content().addMediaType("application/json",
+                                                new MediaType().schema(responseSchema))))
+                                .addApiResponse("401", new ApiResponse()
+                                        .description("로그인 실패 — 비밀번호 불일치(Member-002) 또는 회원 없음(Member-001)")))
+                        .security(List.of()) // 이 엔드포인트는 인증 불필요
+        );
+    }
+
+    private PathItem oauthPathItem() {
+        Parameter providerParam = new Parameter()
+                .in("path")
+                .name("provider")
+                .required(true)
+                .description("소셜 로그인 제공자")
+                .schema(new StringSchema()
+                        ._enum(List.of("kakao", "naver", "google"))
+                        .example("kakao"));
+
+        return new PathItem().get(
+                new Operation()
+                        .tags(List.of("인증 (Security Filter)"))
+                        .summary("소셜 로그인 시작 (브라우저 전용)")
+                        .description(
+                                "Spring Security OAuth2 필터가 처리합니다. **브라우저에서만 동작합니다.**\n\n" +
+                                "**플로우**:\n" +
+                                "1. 브라우저에서 이 URL로 접속\n" +
+                                "2. 소셜 서비스 인증 페이지로 리다이렉트\n" +
+                                "3. 인증 완료 후 `{FRONTEND_CALLBACK_URL}?accessToken=...&refreshToken=...` 으로 최종 리다이렉트\n\n" +
+                                "**콜백 URL**: `http://localhost:3000/auth/callback` (로컬), `https://retrip.io/auth/callback` (운영)\n\n" +
+                                "⚠️ Swagger UI의 Try it out으로는 직접 실행 불가 (리다이렉트 방식).")
+                        .addParametersItem(providerParam)
+                        .responses(new ApiResponses()
+                                .addApiResponse("302", new ApiResponse()
+                                        .description("소셜 인증 페이지로 리다이렉트")))
+                        .security(List.of()) // 인증 불필요
+        );
+    }
+
+    private PathItem reissuePathItem() {
+        Schema<?> responseSchema = new ObjectSchema()
+                .addProperty("accessToken", new StringSchema().description("새로 발급된 JWT Access Token"));
+
+        return new PathItem().post(
+                new Operation()
+                        .tags(List.of("인증 (Security Filter)"))
+                        .summary("Access Token 재발급 (RTR)")
+                        .description(
+                                "HttpOnly Cookie의 refreshToken으로 새 accessToken을 발급합니다.\n\n" +
+                                "**Refresh Token Rotation(RTR)**: 재발급 시 기존 refreshToken은 폐기되고 새 refreshToken이 Cookie로 발급됩니다.\n\n" +
+                                "Swagger에서 호출 시 쿠키가 자동 전송되지 않을 수 있습니다. test.html을 사용하세요.")
+                        .responses(new ApiResponses()
+                                .addApiResponse("200", new ApiResponse()
+                                        .description("재발급 성공")
+                                        .content(new Content().addMediaType("application/json",
+                                                new MediaType().schema(responseSchema))))
+                                .addApiResponse("401", new ApiResponse()
+                                        .description("refreshToken 만료 또는 없음")))
+                        .security(List.of())
+        );
+    }
+
+    private PathItem logoutPathItem() {
+        return new PathItem().post(
+                new Operation()
+                        .tags(List.of("인증 (Security Filter)"))
+                        .summary("로그아웃")
+                        .description(
+                                "서버에 저장된 refreshToken을 삭제하고 Cookie를 만료 처리합니다.\n\n" +
+                                "클라이언트는 저장된 accessToken도 삭제해야 합니다.")
+                        .responses(new ApiResponses()
+                                .addApiResponse("200", new ApiResponse().description("로그아웃 성공")))
+        );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,13 +30,12 @@ spring:
               - email
             redirect-uri: "${APP_BASE_URL:http://localhost:8080}/login/oauth2/code/google"
           kakao:
-            client-id: ${KAKAO_CLIENT_ID:your-kakao-rest-api-key}
-            client-secret: ${KAKAO_CLIENT_SECRET:your-kakao-client-secret}
+            client-id: 04628272071e84065d64a7dd3e83b83a
+            client-secret: BpejrRWuBjd4qx9nNsBiqWYFveFtO4hz
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             scope:
               - profile_nickname
-              - account_email
             redirect-uri: "${APP_BASE_URL:http://localhost:8080}/login/oauth2/code/kakao"
             client-name: Kakao
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,13 +85,16 @@ token:
     header: Authorization
     prefix: Bearer
     access:
-      expire-min: 120
+      expire-min: 30
     refresh:
-      expire-min: 1051200 #2년
+      expire-min: 20160 #14일
 
 springdoc:
   swagger-ui:
     use-root-path: true
+
+app:
+  frontend-callback-url: ${FRONTEND_CALLBACK_URL:http://localhost:3000/auth/callback}
 
 cloud:
   aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,8 +30,8 @@ spring:
               - email
             redirect-uri: "${APP_BASE_URL:http://localhost:8080}/login/oauth2/code/google"
           kakao:
-            client-id: 04628272071e84065d64a7dd3e83b83a
-            client-secret: BpejrRWuBjd4qx9nNsBiqWYFveFtO4hz
+            client-id: ${KAKAO_CLIENT_ID:your-kakao-rest-api-key}
+            client-secret: ${KAKAO_CLIENT_SECRET:your-kakao-client-secret}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             scope:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,7 +28,7 @@ spring:
             scope:
               - profile
               - email
-            redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+            redirect-uri: "${APP_BASE_URL:http://localhost:8080}/login/oauth2/code/google"
           kakao:
             client-id: ${KAKAO_CLIENT_ID:your-kakao-rest-api-key}
             client-secret: ${KAKAO_CLIENT_SECRET:your-kakao-client-secret}
@@ -37,7 +37,7 @@ spring:
             scope:
               - profile_nickname
               - account_email
-            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            redirect-uri: "${APP_BASE_URL:http://localhost:8080}/login/oauth2/code/kakao"
             client-name: Kakao
 
           naver:
@@ -48,7 +48,7 @@ spring:
             scope:
               - name
               - email
-            redirect-uri: "http://localhost:8080/login/oauth2/code/naver"
+            redirect-uri: "${APP_BASE_URL:http://localhost:8080}/login/oauth2/code/naver"
             client-name: Naver
 
         provider:

--- a/src/main/resources/test.html
+++ b/src/main/resources/test.html
@@ -4,270 +4,730 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ReTrip Auth API 통합 테스트</title>
+    <script src="https://cdn.portone.io/v2/browser-sdk.js"></script>
     <style>
         * { box-sizing: border-box; margin: 0; padding: 0; }
-        body { font-family: 'Segoe UI', sans-serif; background: #f0f2f5; padding: 20px; }
-        .page-title { text-align: center; color: #2c3e50; margin: 20px 0 30px; font-size: 24px; font-weight: 700; }
-        .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(420px, 1fr)); gap: 20px; max-width: 1400px; margin: 0 auto; }
-        .card { background: white; border-radius: 10px; padding: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); border-top: 4px solid #667eea; }
-        .card h3 { color: #2c3e50; font-size: 15px; margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
-        .card h3 .badge { background: #667eea; color: white; font-size: 11px; padding: 2px 8px; border-radius: 10px; font-weight: 600; }
-        label { display: block; font-size: 12px; color: #666; margin-bottom: 3px; margin-top: 10px; }
-        input, select { width: 100%; padding: 8px 10px; border: 1px solid #ddd; border-radius: 5px; font-size: 13px; }
-        input:focus, select:focus { outline: none; border-color: #667eea; box-shadow: 0 0 0 2px rgba(102,126,234,0.2); }
-        .btn { margin-top: 14px; width: 100%; padding: 10px; border: none; border-radius: 5px; cursor: pointer; font-size: 14px; font-weight: 600; transition: opacity 0.2s; }
+        body { font-family: 'Segoe UI', sans-serif; background: #f0f2f5; }
+        .page-title { text-align: center; color: #2c3e50; margin: 20px 0 10px; font-size: 22px; font-weight: 700; }
+
+        /* 상단 고정 바 */
+        .sticky-top { position: sticky; top: 0; z-index: 100; background: #f0f2f5; padding: 10px 20px 0; }
+        .config-bar { background: white; border-radius: 8px; padding: 12px 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+        .config-bar label { font-size: 12px; color: #666; white-space: nowrap; }
+        .config-bar input { width: 200px; padding: 6px 8px; border: 1px solid #ddd; border-radius: 5px; font-size: 12px; }
+        .token-bar { background: #eef2ff; border-radius: 8px; padding: 8px 20px; margin-top: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-size: 12px; color: #4338ca; font-family: monospace; display: none; }
+
+        /* 네비게이션 */
+        .nav { background: white; border-radius: 8px; padding: 10px 20px; margin-top: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); display: flex; gap: 6px; flex-wrap: wrap; }
+        .nav a { font-size: 11px; padding: 4px 10px; border-radius: 12px; background: #f1f5f9; color: #475569; text-decoration: none; white-space: nowrap; }
+        .nav a:hover { background: #667eea; color: white; }
+
+        /* 레이아웃 */
+        .content { padding: 16px 20px 40px; max-width: 1400px; margin: 0 auto; }
+        .section { margin-bottom: 32px; }
+        .section-title { font-size: 16px; font-weight: 700; color: #1e293b; margin-bottom: 14px; padding-left: 8px; border-left: 4px solid #667eea; }
+        .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(400px, 1fr)); gap: 16px; }
+
+        /* 카드 */
+        .card { background: white; border-radius: 10px; padding: 18px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+        .card h3 { color: #1e293b; font-size: 13px; margin-bottom: 12px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+        .badge { background: #667eea; color: white; font-size: 11px; padding: 2px 8px; border-radius: 10px; font-weight: 600; white-space: nowrap; }
+        .badge-get { background: #10b981; }
+        .badge-post { background: #667eea; }
+        .badge-put { background: #f59e0b; }
+        .badge-patch { background: #8b5cf6; }
+        .badge-delete { background: #ef4444; }
+        .desc { font-size: 11px; color: #94a3b8; margin-bottom: 10px; }
+
+        /* 폼 요소 */
+        label { display: block; font-size: 11px; color: #64748b; margin-bottom: 3px; margin-top: 8px; }
+        input[type=text], input[type=email], input[type=password], input[type=number], select, textarea {
+            width: 100%; padding: 7px 10px; border: 1px solid #e2e8f0; border-radius: 5px; font-size: 12px; background: #f8fafc;
+        }
+        input:focus, select:focus, textarea:focus { outline: none; border-color: #667eea; background: white; box-shadow: 0 0 0 2px rgba(102,126,234,0.15); }
+        textarea { resize: vertical; min-height: 60px; }
+        .checkbox-row { display: flex; align-items: center; gap: 6px; margin-top: 8px; font-size: 12px; color: #475569; }
+        .checkbox-row input { width: auto; }
+
+        /* 버튼 */
+        .btn { padding: 8px 14px; border: none; border-radius: 6px; cursor: pointer; font-size: 13px; font-weight: 600; transition: opacity 0.15s; }
         .btn:hover { opacity: 0.85; }
+        .btn-block { width: 100%; margin-top: 12px; }
         .btn-primary { background: #667eea; color: white; }
-        .btn-danger { background: #e74c3c; color: white; }
-        .btn-success { background: #27ae60; color: white; }
-        .btn-warning { background: #f39c12; color: white; }
-        .result-box { margin-top: 12px; background: #1e1e2e; border-radius: 6px; overflow: hidden; display: none; }
-        .result-header { display: flex; justify-content: space-between; align-items: center; padding: 6px 12px; background: #2d2d44; font-size: 12px; }
+        .btn-success { background: #10b981; color: white; }
+        .btn-warning { background: #f59e0b; color: white; }
+        .btn-danger { background: #ef4444; color: white; }
+        .btn-purple { background: #8b5cf6; color: white; }
+        .btn-row { display: flex; gap: 8px; margin-top: 12px; }
+        .btn-row .btn { flex: 1; }
+
+        /* 소셜 버튼 */
+        .social-btn { padding: 10px 14px; border: none; border-radius: 6px; cursor: pointer; font-size: 13px; font-weight: 600; width: 100%; margin-top: 8px; }
+        .btn-kakao { background: #FEE500; color: #3C1E1E; }
+        .btn-naver { background: #03C75A; color: white; }
+        .btn-google { background: white; color: #444; border: 1px solid #ddd; }
+
+        /* 결과 박스 */
+        .result-box { margin-top: 10px; background: #1e1e2e; border-radius: 6px; overflow: hidden; display: none; }
+        .result-header { display: flex; justify-content: space-between; align-items: center; padding: 5px 10px; background: #2d2d44; font-size: 11px; }
         .result-header .status { font-weight: 700; }
         .status-ok { color: #50fa7b; }
         .status-err { color: #ff5555; }
-        .result-body { padding: 10px 12px; color: #cdd6f4; font-family: monospace; font-size: 12px; white-space: pre-wrap; word-break: break-all; max-height: 220px; overflow-y: auto; }
-        .token-display { background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 6px; padding: 10px 12px; font-family: monospace; font-size: 11px; word-break: break-all; color: #4338ca; margin-top: 8px; display: none; }
-        .config-bar { background: white; border-radius: 8px; padding: 16px 20px; max-width: 1400px; margin: 0 auto 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
-        .config-bar label { margin: 0; font-size: 12px; color: #666; white-space: nowrap; }
-        .config-bar input { width: 240px; }
-        .config-bar .btn { width: auto; padding: 8px 18px; margin: 0; }
-        .token-bar { background: #eef2ff; border-radius: 8px; padding: 12px 20px; max-width: 1400px; margin: 0 auto 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-size: 12px; color: #4338ca; font-family: monospace; display: none; }
-        .token-bar strong { color: #312e81; }
-        .divider { max-width: 1400px; margin: 0 auto 16px; display: flex; align-items: center; gap: 10px; color: #999; font-size: 13px; font-weight: 600; }
-        .divider::before, .divider::after { content: ''; flex: 1; height: 1px; background: #ddd; }
+        .result-body { padding: 8px 10px; color: #cdd6f4; font-family: monospace; font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 240px; overflow-y: auto; }
+
+        /* 시나리오 */
+        .scenario-card { background: white; border-radius: 10px; padding: 18px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); margin-bottom: 14px; }
+        .scenario-title { font-size: 14px; font-weight: 700; color: #1e293b; margin-bottom: 6px; }
+        .scenario-desc { font-size: 12px; color: #64748b; margin-bottom: 12px; }
+        .scenario-steps { font-size: 11px; color: #94a3b8; margin-bottom: 12px; padding-left: 16px; }
+        .scenario-steps li { margin-bottom: 3px; }
+        .scenario-result { margin-top: 10px; background: #f8fafc; border-radius: 6px; padding: 10px; font-size: 12px; color: #475569; display: none; border-left: 3px solid #667eea; }
+        .scenario-result.pass { border-color: #10b981; background: #f0fdf4; color: #065f46; }
+        .scenario-result.fail { border-color: #ef4444; background: #fef2f2; color: #991b1b; }
+
+        /* 알림 */
+        .info-box { background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 6px; padding: 10px 12px; font-size: 12px; color: #1e40af; margin-bottom: 10px; }
+        .warn-box { background: #fffbeb; border: 1px solid #fde68a; border-radius: 6px; padding: 10px 12px; font-size: 12px; color: #92400e; margin-bottom: 10px; }
+
+        /* 토큰 표시 */
+        .token-display { background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 6px; padding: 8px 10px; font-family: monospace; font-size: 11px; word-break: break-all; color: #4338ca; margin-top: 8px; display: none; }
+
+        /* 여행 스타일 체크박스 그리드 */
+        .style-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; margin-top: 8px; }
+        .style-grid label { margin: 0; display: flex; align-items: center; gap: 4px; font-size: 11px; cursor: pointer; }
+        .style-grid input { width: auto; }
     </style>
 </head>
 <body>
+
 <h1 class="page-title">ReTrip Auth API 통합 테스트</h1>
 
-<!-- 설정 바 -->
-<div class="config-bar">
-    <label>Auth Server</label>
-    <input type="text" id="apiBase" value="http://localhost:8080" style="width:220px;">
-    <label style="margin-left:10px;">Trip Server</label>
-    <input type="text" id="tripBase" value="http://localhost:8081" style="width:220px;">
-    <button class="btn btn-primary" onclick="saveConfig()" style="width:auto;padding:8px 18px;margin:0;">설정 저장</button>
-    <span id="configStatus" style="font-size:12px;color:#27ae60;display:none;">✓ 저장됨</span>
+<div class="sticky-top">
+    <div class="config-bar">
+        <label>Auth URL</label>
+        <input type="text" id="apiBase" value="http://localhost:8080">
+        <label style="margin-left:8px;">Trip URL</label>
+        <input type="text" id="tripBase" value="http://localhost:8081">
+        <label style="margin-left:8px;">PortOne Store ID</label>
+        <input type="text" id="cfgStoreId" placeholder="store-xxx" style="width:260px;">
+        <label style="margin-left:8px;">Channel Key</label>
+        <input type="text" id="cfgChannelKey" placeholder="channel-key-xxx" style="width:260px;">
+        <button class="btn btn-primary" onclick="saveConfig()">저장</button>
+        <span id="cfgOk" style="font-size:12px;color:#10b981;display:none;">✓ 저장됨</span>
+    </div>
+    <div class="token-bar" id="tokenBar">
+        <strong>AccessToken:</strong> <span id="tokenPreview"></span>
+        &nbsp;&nbsp;|&nbsp;&nbsp;
+        <span id="tokenExtra"></span>
+    </div>
+    <div class="nav">
+        <a href="#s1">1.회원가입/로그인</a>
+        <a href="#s2">2.소셜로그인</a>
+        <a href="#s3">3.내정보/프로필</a>
+        <a href="#s4">4.본인인증</a>
+        <a href="#s5">5.프로필수정</a>
+        <a href="#s6">6.이미지</a>
+        <a href="#s7">7.비밀번호</a>
+        <a href="#s8">8.회원정보수정</a>
+        <a href="#s9">9.회원검색</a>
+        <a href="#s10">10.Auth-Trip통합</a>
+        <a href="#s11">11.토큰/로그아웃</a>
+        <a href="#s12">12.회원탈퇴</a>
+        <a href="#s13">13.시나리오검증</a>
+    </div>
 </div>
 
-<!-- 현재 토큰 표시 바 -->
-<div class="token-bar" id="tokenBar">
-    <strong>현재 Access Token:</strong> <span id="tokenPreview"></span>
+<div class="content">
+
+<!-- ==================== 섹션 1: 회원가입/로그인 ==================== -->
+<div class="section" id="s1">
+    <div class="section-title">1. 이메일 회원가입 / 로그인</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-post">POST /users</span> 이메일 회원가입</h3>
+            <div class="desc">닉네임 미입력 시 name 값으로 자동 설정됨 (닉네임 자동설정 검증)</div>
+            <label>이메일</label><input type="email" id="signupEmail" value="user@test.com">
+            <label>비밀번호 (영문+숫자+특수문자 8~20자)</label><input type="password" id="signupPassword" value="Test1234!">
+            <label>이름</label><input type="text" id="signupName" value="홍길동">
+            <label>닉네임 (선택, 최대 15자 — 미입력 시 이름으로 대체)</label>
+            <input type="text" id="signupNickname" placeholder="비워두면 이름으로 자동 설정">
+            <label>성별</label>
+            <select id="signupGender"><option value="M">남성(M)</option><option value="F">여성(F)</option></select>
+            <label>생년월일 (YYYY-MM-DD)</label><input type="text" id="signupBirthDate" placeholder="1995-01-01">
+            <div class="checkbox-row"><input type="checkbox" id="signupTerms" checked><label for="signupTerms" style="margin:0;">필수 약관 동의</label></div>
+            <div class="checkbox-row"><input type="checkbox" id="signupMarketing"><label for="signupMarketing" style="margin:0;">마케팅 수신 동의</label></div>
+            <button class="btn btn-primary btn-block" onclick="signup()">회원가입</button>
+            <div class="result-box" id="signupResult">
+                <div class="result-header"><span class="status" id="signupStatus"></span><span>POST /users</span></div>
+                <div class="result-body" id="signupBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-post">POST /login</span> 이메일 로그인</h3>
+            <div class="desc">요청 필드명은 <code>id</code> (이메일 주소). 성공 시 AccessToken 자동 저장, RefreshToken은 HttpOnly Cookie.</div>
+            <label>이메일 (id 필드)</label><input type="email" id="loginEmail" value="user@test.com">
+            <label>비밀번호</label><input type="password" id="loginPassword" value="Test1234!">
+            <button class="btn btn-primary btn-block" onclick="login()">로그인</button>
+            <div class="token-display" id="loginTokenDisplay"></div>
+            <div class="result-box" id="loginResult">
+                <div class="result-header"><span class="status" id="loginStatus"></span><span>POST /login</span></div>
+                <div class="result-body" id="loginBody"></div>
+            </div>
+        </div>
+
+    </div>
 </div>
 
-<div class="grid">
+<!-- ==================== 섹션 2: 소셜 로그인 ==================== -->
+<div class="section" id="s2">
+    <div class="section-title">2. 소셜 로그인</div>
+    <div class="grid">
 
-    <!-- 1. 회원가입 -->
-    <div class="card">
-        <h3><span class="badge">POST /users</span> 회원가입</h3>
-        <label>이메일</label>
-        <input type="email" id="signupEmail" value="user@test.com">
-        <label>비밀번호 (영문+숫자+특수문자 8~20자)</label>
-        <input type="password" id="signupPassword" value="Test1234!">
-        <label>이름</label>
-        <input type="text" id="signupName" value="테스트유저">
-        <label>닉네임 (선택, 최대 15자)</label>
-        <input type="text" id="signupNickname" placeholder="미입력 시 이름으로 설정">
-        <label>성별</label>
-        <select id="signupGender"><option value="M">남성</option><option value="F">여성</option></select>
-        <label>생년월일 (YYYY-MM-DD, 선택)</label>
-        <input type="text" id="signupBirthDate" placeholder="예: 1995-01-01">
-        <label><input type="checkbox" id="signupTerms" checked style="width:auto;margin-right:5px;">필수 약관 동의</label>
-        <label><input type="checkbox" id="signupMarketing" style="width:auto;margin-right:5px;">마케팅 수신 동의</label>
-        <button class="btn btn-primary" onclick="signup()">회원가입</button>
-        <div class="result-box" id="signupResult">
-            <div class="result-header"><span class="status" id="signupStatus"></span><span>Response</span></div>
-            <div class="result-body" id="signupBody"></div>
+        <div class="card">
+            <h3>소셜 로그인 시작 (브라우저 리다이렉트)</h3>
+            <div class="info-box">
+                소셜 로그인은 브라우저 리다이렉트 방식입니다.<br>
+                버튼 클릭 → 소셜 인증 페이지 → 완료 후 <code>{FRONTEND_CALLBACK_URL}?accessToken=...&amp;refreshToken=...</code> 로 이동.
+            </div>
+            <button class="social-btn btn-kakao" onclick="socialLogin('kakao')">카카오로 로그인</button>
+            <button class="social-btn btn-naver" onclick="socialLogin('naver')">네이버로 로그인</button>
+            <button class="social-btn btn-google" onclick="socialLogin('google')">Google로 로그인</button>
         </div>
+
+        <div class="card">
+            <h3>소셜 로그인 후 토큰 수동 입력</h3>
+            <div class="desc">콜백 URL의 <code>?accessToken=</code> 파라미터를 복사해서 아래에 붙여넣으세요.</div>
+            <div class="warn-box">
+                콜백 URL 예시:<br>
+                <code>http://localhost:3000/auth/callback?accessToken=eyJ...&amp;refreshToken=eyJ...</code>
+            </div>
+            <label>Access Token</label>
+            <textarea id="socialAccessToken" placeholder="소셜 로그인 후 콜백 URL에서 복사"></textarea>
+            <label>Refresh Token (선택)</label>
+            <textarea id="socialRefreshToken" placeholder="refreshToken (있으면 입력)"></textarea>
+            <button class="btn btn-primary btn-block" onclick="setSocialTokens()">토큰 저장하고 사용하기</button>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 3: 내 정보/프로필 ==================== -->
+<div class="section" id="s3">
+    <div class="section-title">3. 내 정보 / 프로필 조회</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-get">GET /users/me</span> 내 기본 정보</h3>
+            <div class="desc">id, email, name, nickname, isVerified, hasPassword, lastLoginProvider</div>
+            <button class="btn btn-success btn-block" onclick="getMe()">조회</button>
+            <div class="result-box" id="meResult">
+                <div class="result-header"><span class="status" id="meStatus"></span><span>GET /users/me</span></div>
+                <div class="result-body" id="meBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-get">GET /api/users/profile</span> 전체 프로필</h3>
+            <div class="desc">linkedProviders 배열, hasPassword, bio, mbti, travelStyles 포함</div>
+            <button class="btn btn-success btn-block" onclick="getProfile()">조회</button>
+            <div class="result-box" id="profileResult">
+                <div class="result-header"><span class="status" id="profileStatus"></span><span>GET /api/users/profile</span></div>
+                <div class="result-body" id="profileBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-get">GET /api/travel-styles</span> 여행 스타일 목록</h3>
+            <div class="desc">인증 불필요. 프로필 수정 시 선택할 수 있는 여행 스타일 전체 목록.</div>
+            <button class="btn btn-success btn-block" onclick="getTravelStyles()">조회</button>
+            <div class="result-box" id="travelStylesResult">
+                <div class="result-header"><span class="status" id="travelStylesStatus"></span><span>GET /api/travel-styles</span></div>
+                <div class="result-body" id="travelStylesBody"></div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 4: 본인인증 ==================== -->
+<div class="section" id="s4">
+    <div class="section-title">4. PortOne 본인인증</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3>PortOne V2 SDK — 본인인증 시작</h3>
+            <div class="info-box">
+                상단 Config 바에 <strong>PortOne Store ID</strong>와 <strong>Channel Key</strong>를 먼저 입력하세요.<br>
+                (<code>application-local.yml</code>의 portone.public.store-id / channel-key 값)
+            </div>
+            <div class="desc">버튼 클릭 → PortOne 인증 팝업 → 완료 시 자동으로 서버 API 호출</div>
+            <button class="btn btn-purple btn-block" onclick="startIdentityVerification()">본인인증 시작 (SDK)</button>
+            <div id="portoneStatus" style="margin-top:8px;font-size:12px;color:#64748b;"></div>
+            <div class="result-box" id="verifyIdentityResult">
+                <div class="result-header"><span class="status" id="verifyIdentityStatus"></span><span>POST /api/auth/verify-identity</span></div>
+                <div class="result-body" id="verifyIdentityBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-post">POST /api/auth/verify-identity</span> 수동 impUid 입력</h3>
+            <div class="desc">SDK 없이 직접 impUid(identityVerificationId)를 입력해서 서버 검증 호출</div>
+            <div class="warn-box">
+                PortOne 테스트 콘솔에서 본인인증 완료 후 발급된 <code>identityVerificationId</code>를 사용하세요.
+            </div>
+            <label>impUid (identityVerificationId)</label>
+            <input type="text" id="manualImpUid" placeholder="identity-xxxxxxxxxx">
+            <button class="btn btn-purple btn-block" onclick="verifyIdentityManual()">서버 검증 호출</button>
+            <div class="result-box" id="verifyIdentityManualResult">
+                <div class="result-header"><span class="status" id="verifyIdentityManualStatus"></span><span>POST /api/auth/verify-identity</span></div>
+                <div class="result-body" id="verifyIdentityManualBody"></div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 5: 프로필 수정 ==================== -->
+<div class="section" id="s5">
+    <div class="section-title">5. 프로필 수정</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-put">PUT /api/users/profile</span> 프로필 수정</h3>
+            <label>닉네임 (최대 15자)</label><input type="text" id="profileNickname" placeholder="닉네임">
+            <label>소개 (최대 30자)</label><input type="text" id="profileBio" placeholder="한 줄 소개">
+            <label>MBTI (최대 4자)</label><input type="text" id="profileMbti" placeholder="INTJ" maxlength="4">
+            <label>프로필 이미지 URL</label><input type="text" id="profileImageUrl" placeholder="https://...">
+            <label>여행 스타일 (최대 3개)</label>
+            <div class="style-grid" id="travelStyleCheckboxes">
+                <label><input type="checkbox" name="travelStyle" value="1"> 힐링여행</label>
+                <label><input type="checkbox" name="travelStyle" value="2"> 액티비티</label>
+                <label><input type="checkbox" name="travelStyle" value="3"> 맛집탐방</label>
+                <label><input type="checkbox" name="travelStyle" value="4"> 문화탐방</label>
+                <label><input type="checkbox" name="travelStyle" value="5"> 자연경관</label>
+                <label><input type="checkbox" name="travelStyle" value="6"> 쇼핑</label>
+            </div>
+            <button class="btn btn-warning btn-block" onclick="updateProfile()">프로필 수정</button>
+            <div class="result-box" id="updateProfileResult">
+                <div class="result-header"><span class="status" id="updateProfileStatus"></span><span>PUT /api/users/profile</span></div>
+                <div class="result-body" id="updateProfileBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-patch">PATCH /api/users/notification-settings</span> 알림 설정</h3>
+            <div class="desc">마스터 알림 토글 (true/false)</div>
+            <label>알림 활성화</label>
+            <select id="notifEnabled"><option value="true">활성화 (true)</option><option value="false">비활성화 (false)</option></select>
+            <button class="btn btn-warning btn-block" onclick="updateNotification()">알림 설정 변경</button>
+            <div class="result-box" id="notifResult">
+                <div class="result-header"><span class="status" id="notifStatus"></span><span>PATCH /api/users/notification-settings</span></div>
+                <div class="result-body" id="notifBody"></div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 6: 이미지 ==================== -->
+<div class="section" id="s6">
+    <div class="section-title">6. 이미지 Presigned URL</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-post">POST /images/presigned-url</span> Presigned URL 발급</h3>
+            <div class="desc">S3 PUT 업로드용 Presigned URL + 읽기 URL 반환</div>
+            <label>파일 확장자</label>
+            <select id="imgExtension">
+                <option value="JPG">JPG</option>
+                <option value="PNG">PNG</option>
+                <option value="HEIC">HEIC</option>
+                <option value="WEBP">WEBP</option>
+            </select>
+            <button class="btn btn-primary btn-block" onclick="getPresignedUrl()">Presigned URL 발급</button>
+            <div id="presignedUrlDisplay" style="display:none;margin-top:10px;">
+                <div style="font-size:11px;color:#64748b;margin-bottom:4px;">readImageUrl (프로필 이미지 URL로 사용):</div>
+                <div id="readImageUrlVal" style="font-size:11px;font-family:monospace;word-break:break-all;background:#f8fafc;padding:6px;border-radius:4px;border:1px solid #e2e8f0;"></div>
+                <button class="btn btn-success btn-block" onclick="copyReadUrl()" style="margin-top:6px;font-size:12px;">readImageUrl 복사</button>
+            </div>
+            <div class="result-box" id="presignedResult">
+                <div class="result-header"><span class="status" id="presignedStatus"></span><span>POST /images/presigned-url</span></div>
+                <div class="result-body" id="presignedBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3>S3 직접 PUT 업로드 테스트</h3>
+            <div class="desc">Presigned URL을 사용해서 실제 파일을 S3에 직접 업로드합니다.</div>
+            <div class="warn-box">Presigned URL 발급 먼저 실행 후 사용하세요.</div>
+            <label>파일 선택</label>
+            <input type="file" id="uploadFile" accept="image/*">
+            <button class="btn btn-success btn-block" onclick="uploadToS3()">S3 업로드</button>
+            <div id="uploadStatus" style="margin-top:8px;font-size:12px;color:#64748b;"></div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 7: 비밀번호 ==================== -->
+<div class="section" id="s7">
+    <div class="section-title">7. 비밀번호</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-post">POST /users/verify-password</span> 비밀번호 확인</h3>
+            <label>비밀번호</label><input type="password" id="verifyPwInput" value="Test1234!">
+            <button class="btn btn-warning btn-block" onclick="verifyPassword()">확인</button>
+            <div class="result-box" id="verifyPwResult">
+                <div class="result-header"><span class="status" id="verifyPwStatus"></span><span>POST /users/verify-password</span></div>
+                <div class="result-body" id="verifyPwBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-patch">PATCH /users/password</span> 비밀번호 변경</h3>
+            <div class="desc">소셜 전용 계정(hasPassword=false)은 403 Member-007 반환</div>
+            <label>현재 비밀번호</label><input type="password" id="changePwCurrent" value="Test1234!">
+            <label>새 비밀번호</label><input type="password" id="changePwNew" value="NewPass1234!">
+            <button class="btn btn-warning btn-block" onclick="changePassword()">비밀번호 변경</button>
+            <div class="result-box" id="changePwResult">
+                <div class="result-header"><span class="status" id="changePwStatus"></span><span>PATCH /users/password</span></div>
+                <div class="result-body" id="changePwBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-post">POST /users/password</span> 최초 비밀번호 설정 (소셜 전용)</h3>
+            <div class="desc">hasPassword=false인 소셜 계정에서만 성공. 이미 설정됐으면 409 Member-008.</div>
+            <label>설정할 비밀번호</label><input type="password" id="setInitialPw" value="InitialPw1234!">
+            <button class="btn btn-purple btn-block" onclick="setInitialPassword()">최초 비밀번호 설정</button>
+            <div class="result-box" id="setInitialPwResult">
+                <div class="result-header"><span class="status" id="setInitialPwStatus"></span><span>POST /users/password</span></div>
+                <div class="result-body" id="setInitialPwBody"></div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 8: 회원 정보 수정 ==================== -->
+<div class="section" id="s8">
+    <div class="section-title">8. 회원 정보 수정 (isVerified 잠금 테스트)</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-put">PUT /users</span> 회원 정보 수정</h3>
+            <div class="warn-box">
+                본인인증 완료(isVerified=true) 상태에서는 <strong>name, birthDate</strong> 변경 시 400 Member-006.<br>
+                gender 변경은 항상 가능.
+            </div>
+            <label>현재 비밀번호 (소셜 유저는 빈칸)</label>
+            <input type="password" id="updatePwCurrent" placeholder="소셜 유저면 비워두세요">
+            <label>새 비밀번호 (변경 원할 때만)</label>
+            <input type="password" id="updatePwNew" placeholder="빈칸이면 유지">
+            <label>이름 (isVerified=true면 변경 불가)</label>
+            <input type="text" id="updateInfoName" placeholder="이름 변경">
+            <label>성별</label>
+            <select id="updateInfoGender">
+                <option value="">변경 안 함</option>
+                <option value="M">남성(M)</option>
+                <option value="F">여성(F)</option>
+            </select>
+            <label>생년월일 (isVerified=true면 변경 불가)</label>
+            <input type="text" id="updateInfoBirth" placeholder="YYYY-MM-DD">
+            <button class="btn btn-warning btn-block" onclick="updateUserInfo()">정보 수정</button>
+            <div class="result-box" id="updateInfoResult">
+                <div class="result-header"><span class="status" id="updateInfoStatus"></span><span>PUT /users</span></div>
+                <div class="result-body" id="updateInfoBody"></div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 9: 회원 검색 ==================== -->
+<div class="section" id="s9">
+    <div class="section-title">9. 회원 검색 / 배치 조회</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-get">GET /users/search</span> 이름 검색</h3>
+            <div class="desc">Trip 도메인에서 여행 초대 대상 검색에 사용</div>
+            <label>이름 (부분 일치)</label><input type="text" id="searchNameInput" value="홍">
+            <button class="btn btn-success btn-block" onclick="searchByName()">검색</button>
+            <div class="result-box" id="searchNameResult">
+                <div class="result-header"><span class="status" id="searchNameStatus"></span><span>GET /users/search</span></div>
+                <div class="result-body" id="searchNameBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-get">GET /users/members</span> 배치 조회</h3>
+            <div class="desc">UUID 쉼표 구분. Trip 도메인에서 여행 멤버 정보 조회에 사용.</div>
+            <label>UUID 목록 (쉼표 구분)</label>
+            <textarea id="memberIdsInput" placeholder="uuid1,uuid2,uuid3"></textarea>
+            <button class="btn btn-success btn-block" onclick="getMembers()">조회</button>
+            <div class="result-box" id="membersResult">
+                <div class="result-header"><span class="status" id="membersStatus"></span><span>GET /users/members</span></div>
+                <div class="result-body" id="membersBody"></div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 10: Auth-Trip 통합 ==================== -->
+<div class="section" id="s10">
+    <div class="section-title">10. Auth-Trip 통합 (Trip 서버 필요)</div>
+    <div class="info-box">Trip 서버(기본 localhost:8081)가 실행 중이어야 합니다. auth의 JWT를 그대로 사용합니다.</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-post">POST {trip}/trips</span> 여행 생성</h3>
+            <label>여행 제목</label><input type="text" id="tripTitle" value="테스트 여행">
+            <label>설명</label><input type="text" id="tripDesc" value="통합 테스트 여행입니다.">
+            <label>시작일 (YYYY-MM-DD)</label><input type="text" id="tripStart" value="2026-05-01">
+            <label>종료일 (YYYY-MM-DD)</label><input type="text" id="tripEnd" value="2026-05-10">
+            <div class="checkbox-row"><input type="checkbox" id="tripPublic" checked><label for="tripPublic" style="margin:0;">공개 여행</label></div>
+            <button class="btn btn-primary btn-block" onclick="createTrip()">여행 생성</button>
+            <div class="result-box" id="createTripResult">
+                <div class="result-header"><span class="status" id="createTripStatus"></span><span>POST {trip}/trips</span></div>
+                <div class="result-body" id="createTripBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-get">GET {trip}/trips/my</span> 내 여행 목록</h3>
+            <div class="desc">auth의 JWT에서 userId를 파싱하여 해당 멤버의 여행 목록 반환</div>
+            <button class="btn btn-success btn-block" onclick="getMyTrips()">내 여행 조회</button>
+            <div class="result-box" id="myTripsResult">
+                <div class="result-header"><span class="status" id="myTripsStatus"></span><span>GET {trip}/trips/my</span></div>
+                <div class="result-body" id="myTripsBody"></div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 11: 토큰/로그아웃 ==================== -->
+<div class="section" id="s11">
+    <div class="section-title">11. 토큰 재발급 / 로그아웃</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-post">POST /auth/reissue</span> 토큰 재발급 (RTR)</h3>
+            <div class="desc">HttpOnly Cookie의 refreshToken으로 새 AccessToken 발급. 기존 refreshToken은 폐기(RTR).</div>
+            <button class="btn btn-success btn-block" onclick="reissue()">토큰 재발급</button>
+            <div class="result-box" id="reissueResult">
+                <div class="result-header"><span class="status" id="reissueStatus"></span><span>POST /auth/reissue</span></div>
+                <div class="result-body" id="reissueBody"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3><span class="badge badge-post">POST /auth/logout</span> 로그아웃</h3>
+            <div class="desc">서버 refreshToken 삭제 + Cookie 만료. 저장된 accessToken도 초기화.</div>
+            <button class="btn btn-danger btn-block" onclick="logout()">로그아웃</button>
+            <div class="result-box" id="logoutResult">
+                <div class="result-header"><span class="status" id="logoutStatus"></span><span>POST /auth/logout</span></div>
+                <div class="result-body" id="logoutBody"></div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 12: 회원 탈퇴 ==================== -->
+<div class="section" id="s12">
+    <div class="section-title">12. 회원 탈퇴</div>
+    <div class="grid">
+
+        <div class="card">
+            <h3><span class="badge badge-delete">DELETE /users</span> 회원 탈퇴</h3>
+            <div class="warn-box">탈퇴한 이메일은 재가입 불가 (Member-003). 탈퇴 성공 시 토큰 전체 초기화.</div>
+            <div class="checkbox-row">
+                <input type="checkbox" id="deleteIsSocial" onchange="toggleDeletePw()">
+                <label for="deleteIsSocial" style="margin:0;">소셜 전용 계정 (비밀번호 없음)</label>
+            </div>
+            <div id="deletePwSection">
+                <label>비밀번호 (이메일 유저)</label>
+                <input type="password" id="deletePwInput" value="Test1234!">
+            </div>
+            <button class="btn btn-danger btn-block" onclick="deleteUser()">회원 탈퇴</button>
+            <div class="result-box" id="deleteUserResult">
+                <div class="result-header"><span class="status" id="deleteUserStatus"></span><span>DELETE /users</span></div>
+                <div class="result-body" id="deleteUserBody"></div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<!-- ==================== 섹션 13: 시나리오 검증 ==================== -->
+<div class="section" id="s13">
+    <div class="section-title">13. 시나리오 검증</div>
+
+    <!-- 시나리오 A -->
+    <div class="scenario-card">
+        <div class="scenario-title">시나리오 A — 닉네임 자동 설정 검증</div>
+        <div class="scenario-desc">닉네임 없이 가입 시 GET /users/me 응답의 nickname 값이 name과 동일한지 확인</div>
+        <ol class="scenario-steps">
+            <li>nickname 미입력으로 회원가입</li>
+            <li>GET /users/me 호출</li>
+            <li>응답의 nickname == name 확인 ✅</li>
+        </ol>
+        <label>이메일</label><input type="email" id="scA_email" value="scenario_a@test.com">
+        <label>비밀번호</label><input type="password" id="scA_pw" value="Test1234!">
+        <label>이름</label><input type="text" id="scA_name" value="시나리오A">
+        <button class="btn btn-primary" onclick="runScenarioA()">시나리오 A 실행</button>
+        <div class="scenario-result" id="scA_result"></div>
     </div>
 
-    <!-- 2. 로그인 -->
-    <div class="card">
-        <h3><span class="badge">POST /login</span> 로그인</h3>
-        <label>이메일 (id 필드)</label>
-        <input type="email" id="loginEmail" value="user@test.com">
-        <label>비밀번호</label>
-        <input type="password" id="loginPassword" value="Test1234!">
-        <button class="btn btn-primary" onclick="login()">로그인</button>
-        <div id="loginTokenDisplay" class="token-display"></div>
-        <div class="result-box" id="loginResult">
-            <div class="result-header"><span class="status" id="loginStatus"></span><span>Response</span></div>
-            <div class="result-body" id="loginBody"></div>
-        </div>
+    <!-- 시나리오 B -->
+    <div class="scenario-card">
+        <div class="scenario-title">시나리오 B — hasPassword 분기 검증</div>
+        <div class="scenario-desc">현재 로그인된 계정 기준. 소셜 전용 계정(hasPassword=false)에서 비밀번호 관련 API 동작 확인.</div>
+        <ol class="scenario-steps">
+            <li>GET /api/users/profile → hasPassword 값 확인</li>
+            <li>hasPassword=false면: POST /users/password → 200 성공</li>
+            <li>hasPassword=false면: PATCH /users/password → 403 Member-007</li>
+            <li>hasPassword=true면: POST /users/password → 409 Member-008</li>
+        </ol>
+        <div class="info-box">현재 저장된 토큰으로 실행됩니다. 소셜 로그인 후 토큰을 저장하세요.</div>
+        <label>설정할 새 비밀번호 (소셜 전용 계정용)</label>
+        <input type="password" id="scB_newPw" value="ScenarioBPw1!">
+        <button class="btn btn-purple" onclick="runScenarioB()">시나리오 B 실행</button>
+        <div class="scenario-result" id="scB_result"></div>
     </div>
 
-    <!-- 3. 내 정보 조회 -->
-    <div class="card">
-        <h3><span class="badge">GET /users/me</span> 내 정보 조회</h3>
-        <p style="font-size:12px;color:#888;margin-bottom:8px;">로그인 후 자동으로 토큰 사용</p>
-        <button class="btn btn-success" onclick="getMe()">내 정보 조회</button>
-        <div class="result-box" id="meResult">
-            <div class="result-header"><span class="status" id="meStatus"></span><span>Response</span></div>
-            <div class="result-body" id="meBody"></div>
-        </div>
+    <!-- 시나리오 C -->
+    <div class="scenario-card">
+        <div class="scenario-title">시나리오 C — isVerified 잠금 검증</div>
+        <div class="scenario-desc">본인인증 완료 후 이름/생년월일 변경 시도 → 400 Member-006, 성별 변경은 가능 → 200</div>
+        <ol class="scenario-steps">
+            <li>현재 isVerified 상태 확인 (GET /users/me)</li>
+            <li>PUT /users {name: "변경시도"} → 400 Member-006 ✅</li>
+            <li>PUT /users {gender: "F"} → 200 성공 ✅</li>
+        </ol>
+        <div class="info-box">본인인증(섹션 4)이 완료된 계정에서 실행하세요.</div>
+        <label>현재 비밀번호 (소셜 유저면 빈칸)</label>
+        <input type="password" id="scC_pw" placeholder="소셜 유저면 비워두세요">
+        <button class="btn btn-warning" onclick="runScenarioC()">시나리오 C 실행</button>
+        <div class="scenario-result" id="scC_result"></div>
     </div>
 
-    <!-- 4. 비밀번호 확인 -->
-    <div class="card">
-        <h3><span class="badge">POST /users/verify-password</span> 비밀번호 확인</h3>
-        <label>비밀번호 입력</label>
-        <input type="password" id="verifyPw" value="Test1234!">
-        <button class="btn btn-warning" onclick="verifyPassword()">비밀번호 확인</button>
-        <div class="result-box" id="verifyResult">
-            <div class="result-header"><span class="status" id="verifyStatus"></span><span>Response</span></div>
-            <div class="result-body" id="verifyBody"></div>
-        </div>
+    <!-- 시나리오 D -->
+    <div class="scenario-card">
+        <div class="scenario-title">시나리오 D — 소셜 계정 연동 검증 (이메일 자동 링크)</div>
+        <div class="scenario-desc">동일 이메일로 다른 소셜 로그인 시 linkedProviders 배열에 항목이 추가되는지 확인</div>
+        <ol class="scenario-steps">
+            <li>카카오로 로그인 (섹션 2)</li>
+            <li>GET /api/users/profile → linkedProviders 배열 확인</li>
+            <li>같은 이메일로 네이버 로그인</li>
+            <li>GET /api/users/profile → linkedProviders에 naver 추가 확인 ✅</li>
+        </ol>
+        <div class="info-box">현재 저장된 토큰으로 프로필을 조회해서 linkedProviders를 확인합니다.</div>
+        <button class="btn btn-success" onclick="runScenarioD()">시나리오 D — 프로필 조회 (linkedProviders 확인)</button>
+        <div class="scenario-result" id="scD_result"></div>
     </div>
 
-    <!-- 5. 회원정보 수정 -->
-    <div class="card">
-        <h3><span class="badge">PUT /users</span> 회원정보 수정</h3>
-        <label>현재 비밀번호</label>
-        <input type="password" id="updateCurrentPw" value="Test1234!">
-        <label>새 비밀번호 (변경 시, 빈칸이면 유지)</label>
-        <input type="password" id="updateNewPw" placeholder="빈칸이면 변경 안 함">
-        <label>이름</label>
-        <input type="text" id="updateName" value="수정된이름">
-        <label>성별</label>
-        <select id="updateGender"><option value="M">남성</option><option value="F">여성</option></select>
-        <label>생년월일</label>
-        <input type="text" id="updateBirthDate" placeholder="예: 1995-06-15">
-        <button class="btn btn-warning" onclick="updateUser()">정보 수정</button>
-        <div class="result-box" id="updateResult">
-            <div class="result-header"><span class="status" id="updateStatus"></span><span>Response</span></div>
-            <div class="result-body" id="updateBody"></div>
-        </div>
-    </div>
-
-    <!-- 6. 비밀번호 변경 -->
-    <div class="card">
-        <h3><span class="badge">PATCH /users/password</span> 비밀번호 변경</h3>
-        <label>현재 비밀번호</label>
-        <input type="password" id="changeCurrent" value="Test1234!">
-        <label>새 비밀번호</label>
-        <input type="password" id="changeNew" value="NewPass1234!">
-        <button class="btn btn-warning" onclick="changePassword()">비밀번호 변경</button>
-        <div class="result-box" id="changeResult">
-            <div class="result-header"><span class="status" id="changeStatus"></span><span>Response</span></div>
-            <div class="result-body" id="changeBody"></div>
-        </div>
-    </div>
-
-    <!-- 7. 토큰 재발급 -->
-    <div class="card">
-        <h3><span class="badge">POST /auth/reissue</span> 토큰 재발급</h3>
-        <p style="font-size:12px;color:#888;margin-bottom:8px;">저장된 refreshToken 쿠키로 재발급합니다.</p>
-        <label>현재 Refresh Token</label>
-        <input type="text" id="reissueToken" placeholder="로그인 후 자동 설정됨">
-        <button class="btn btn-success" onclick="reissue()">재발급</button>
-        <div class="result-box" id="reissueResult">
-            <div class="result-header"><span class="status" id="reissueStatus"></span><span>Response</span></div>
-            <div class="result-body" id="reissueBody"></div>
-        </div>
-    </div>
-
-    <!-- 8. 로그아웃 -->
-    <div class="card">
-        <h3><span class="badge">POST /auth/logout</span> 로그아웃</h3>
-        <p style="font-size:12px;color:#888;margin-bottom:8px;">refreshToken 쿠키를 만료 처리합니다.</p>
-        <button class="btn btn-danger" onclick="logout()">로그아웃</button>
-        <div class="result-box" id="logoutResult">
-            <div class="result-header"><span class="status" id="logoutStatus"></span><span>Response</span></div>
-            <div class="result-body" id="logoutBody"></div>
-        </div>
-    </div>
-
-    <!-- 9. 회원탈퇴 -->
-    <div class="card">
-        <h3><span class="badge">DELETE /users</span> 회원탈퇴</h3>
-        <label>비밀번호 확인</label>
-        <input type="password" id="deletePw" value="Test1234!">
-        <button class="btn btn-danger" onclick="deleteUser()">회원탈퇴</button>
-        <div class="result-box" id="deleteResult">
-            <div class="result-header"><span class="status" id="deleteStatus"></span><span>Response</span></div>
-            <div class="result-body" id="deleteBody"></div>
-        </div>
-    </div>
-
-    <!-- 10. 이름 검색 -->
-    <div class="card">
-        <h3><span class="badge">GET /users/search</span> 이름으로 회원 검색</h3>
-        <label>이름 (부분 일치)</label>
-        <input type="text" id="searchName" value="테스트">
-        <button class="btn btn-success" onclick="searchUsers()">검색</button>
-        <div class="result-box" id="searchResult">
-            <div class="result-header"><span class="status" id="searchStatus"></span><span>Response</span></div>
-            <div class="result-body" id="searchBody"></div>
-        </div>
+    <!-- 시나리오 E -->
+    <div class="scenario-card">
+        <div class="scenario-title">시나리오 E — 소셜 유저 탈퇴 검증</div>
+        <div class="scenario-desc">비밀번호 없는 소셜 전용 계정에서 탈퇴 (body 없이) → 204 성공</div>
+        <ol class="scenario-steps">
+            <li>소셜 로그인 후 토큰 저장 (섹션 2)</li>
+            <li>GET /users/me → hasPassword=false 확인</li>
+            <li>DELETE /users (password 없이) → 204 ✅</li>
+            <li>동일 이메일로 재가입 시도 → 400 Member-003 ✅</li>
+        </ol>
+        <div class="warn-box">실행 시 실제로 탈퇴됩니다. 테스트 계정에서만 사용하세요.</div>
+        <label>재가입 시도 이메일 (탈퇴 후 테스트용)</label>
+        <input type="email" id="scE_email" placeholder="탈퇴 후 재가입 시도할 이메일">
+        <button class="btn btn-danger" onclick="runScenarioE()">시나리오 E 실행 (탈퇴 후 재가입 시도)</button>
+        <div class="scenario-result" id="scE_result"></div>
     </div>
 
 </div>
+
+</div><!-- /content -->
 
 <script>
     let STATE = {
         apiBase: 'http://localhost:8080',
         tripBase: 'http://localhost:8081',
         accessToken: '',
-        refreshToken: ''
+        storeId: '',
+        channelKey: '',
+        presignedUrl: '',
+        readImageUrl: ''
     };
 
+    // ===================== CONFIG =====================
     function saveConfig() {
         STATE.apiBase = document.getElementById('apiBase').value.replace(/\/$/, '');
         STATE.tripBase = document.getElementById('tripBase').value.replace(/\/$/, '');
-        const s = document.getElementById('configStatus');
+        STATE.storeId = document.getElementById('cfgStoreId').value;
+        STATE.channelKey = document.getElementById('cfgChannelKey').value;
+        const s = document.getElementById('cfgOk');
         s.style.display = 'inline';
         setTimeout(() => s.style.display = 'none', 2000);
     }
 
-    function setTokens(access, refresh) {
-        STATE.accessToken = access || STATE.accessToken;
-        STATE.refreshToken = refresh || STATE.refreshToken;
-        if (STATE.accessToken) {
-            const bar = document.getElementById('tokenBar');
-            bar.style.display = 'block';
-            document.getElementById('tokenPreview').textContent = STATE.accessToken.substring(0, 40) + '...';
-            document.getElementById('loginTokenDisplay').style.display = 'block';
-            document.getElementById('loginTokenDisplay').textContent =
-                'Access:  ' + STATE.accessToken.substring(0, 50) + '...\nRefresh: ' + (STATE.refreshToken || '(쿠키에 저장됨)').substring(0, 50);
-            if (STATE.refreshToken) {
-                document.getElementById('reissueToken').value = STATE.refreshToken;
-            }
-        }
+    function setToken(access) {
+        if (!access) return;
+        STATE.accessToken = access;
+        document.getElementById('tokenBar').style.display = 'block';
+        document.getElementById('tokenPreview').textContent = access.substring(0, 50) + '...';
+        // JWT payload 파싱
+        try {
+            const payload = JSON.parse(atob(access.split('.')[1]));
+            const exp = payload.exp ? new Date(payload.exp * 1000).toLocaleTimeString() : '?';
+            document.getElementById('tokenExtra').textContent =
+                `nickname: ${payload.nickname || '-'} | exp: ${exp}`;
+        } catch(e) { document.getElementById('tokenExtra').textContent = ''; }
+        // 로그인 토큰 표시
+        const d = document.getElementById('loginTokenDisplay');
+        d.style.display = 'block';
+        d.textContent = access.substring(0, 60) + '...';
     }
 
-    function show(id, status, body, isError) {
+    function showResult(id, status, body, isErr) {
         const box = document.getElementById(id + 'Result');
         box.style.display = 'block';
         const st = document.getElementById(id + 'Status');
         st.textContent = status;
-        st.className = 'status ' + (isError ? 'status-err' : 'status-ok');
+        st.className = 'status ' + (isErr ? 'status-err' : 'status-ok');
         document.getElementById(id + 'Body').textContent =
-            typeof body === 'object' ? JSON.stringify(body, null, 2) : body;
+            typeof body === 'object' ? JSON.stringify(body, null, 2) : String(body);
     }
 
-    async function call(method, path, body, resultId, useToken) {
-        const url = STATE.apiBase + path;
+    async function api(method, path, body, resultId, useToken, baseUrl) {
+        const base = baseUrl || STATE.apiBase;
+        const url = base + path;
         const headers = { 'Content-Type': 'application/json' };
         if (useToken && STATE.accessToken) {
             headers['Authorization'] = 'Bearer ' + STATE.accessToken;
         }
         try {
             const opts = { method, headers, credentials: 'include' };
-            if (body !== null) opts.body = JSON.stringify(body);
+            if (body !== null && body !== undefined) opts.body = JSON.stringify(body);
             const res = await fetch(url, opts);
             const text = await res.text();
             let parsed;
             try { parsed = JSON.parse(text); } catch { parsed = text; }
-            const isError = !res.ok;
-            show(resultId, res.status + ' ' + (isError ? '❌' : '✅'), parsed, isError);
-            return { ok: !isError, status: res.status, data: parsed };
-        } catch (e) {
-            show(resultId, '네트워크 오류 ❌', e.message, true);
-            return { ok: false };
+            const isErr = !res.ok;
+            if (resultId) showResult(resultId, res.status + ' ' + (isErr ? '❌' : '✅'), parsed, isErr);
+            return { ok: !isErr, status: res.status, data: parsed };
+        } catch(e) {
+            if (resultId) showResult(resultId, '네트워크 오류 ❌', e.message, true);
+            return { ok: false, status: 0, data: e.message };
         }
     }
 
+    // ===================== 섹션 1 =====================
     async function signup() {
         const body = {
             email: document.getElementById('signupEmail').value,
@@ -279,9 +739,10 @@
             termsAgreed: document.getElementById('signupTerms').checked,
             marketingAgreed: document.getElementById('signupMarketing').checked
         };
-        const r = await call('POST', '/users', body, 'signup', false);
-        if (r.ok && r.data?.data) {
-            setTokens(r.data.data.accessToken, r.data.data.refreshToken);
+        const r = await api('POST', '/users', body, 'signup', false);
+        if (r.ok) {
+            const token = r.data?.data?.accessToken || r.data?.accessToken;
+            if (token) setToken(token);
             document.getElementById('loginEmail').value = body.email;
             document.getElementById('loginPassword').value = body.password;
         }
@@ -292,77 +753,388 @@
             id: document.getElementById('loginEmail').value,
             password: document.getElementById('loginPassword').value
         };
-        const r = await call('POST', '/login', body, 'login', false);
-        if (r.ok && r.data?.data) {
-            setTokens(r.data.data.accessToken, r.data.data.refreshToken);
+        const r = await api('POST', '/login', body, 'login', false);
+        if (r.ok) {
+            const token = r.data?.data?.accessToken || r.data?.accessToken;
+            if (token) setToken(token);
         }
     }
 
-    async function getMe() {
-        await call('GET', '/users/me', null, 'me', true);
+    // ===================== 섹션 2 =====================
+    function socialLogin(provider) {
+        window.open(STATE.apiBase + '/oauth2/authorization/' + provider, '_blank', 'width=600,height=700');
     }
 
-    async function verifyPassword() {
-        await call('POST', '/users/verify-password', {
-            password: document.getElementById('verifyPw').value
-        }, 'verify', true);
+    function setSocialTokens() {
+        const at = document.getElementById('socialAccessToken').value.trim();
+        if (at) setToken(at);
+        alert('토큰이 저장되었습니다. 이제 인증이 필요한 API를 사용할 수 있습니다.');
     }
 
-    async function updateUser() {
-        const newPw = document.getElementById('updateNewPw').value;
+    // ===================== 섹션 3 =====================
+    async function getMe() { await api('GET', '/users/me', null, 'me', true); }
+    async function getProfile() { await api('GET', '/api/users/profile', null, 'profile', true); }
+    async function getTravelStyles() { await api('GET', '/api/travel-styles', null, 'travelStyles', false); }
+
+    // ===================== 섹션 4 =====================
+    async function startIdentityVerification() {
+        const storeId = STATE.storeId || document.getElementById('cfgStoreId').value;
+        const channelKey = STATE.channelKey || document.getElementById('cfgChannelKey').value;
+        if (!storeId || !channelKey) {
+            alert('상단 Config 바에 PortOne Store ID와 Channel Key를 먼저 입력하고 저장하세요.');
+            return;
+        }
+        if (typeof PortOne === 'undefined') {
+            document.getElementById('portoneStatus').textContent = '⚠️ PortOne SDK 로드 실패. 수동 입력을 사용하세요.';
+            return;
+        }
+        document.getElementById('portoneStatus').textContent = '⏳ 본인인증 팝업을 여는 중...';
+        try {
+            const result = await PortOne.requestIdentityVerification({
+                storeId,
+                channelKey,
+                identityVerificationId: 'identity-' + Date.now(),
+                customer: { name: '' }
+            });
+            if (result.code) {
+                document.getElementById('portoneStatus').textContent = '❌ 인증 실패: ' + (result.message || result.code);
+                return;
+            }
+            document.getElementById('portoneStatus').textContent = '✅ 인증 완료. 서버 검증 중...';
+            document.getElementById('manualImpUid').value = result.identityVerificationId;
+            await callVerifyIdentity(result.identityVerificationId, 'verifyIdentity');
+        } catch(e) {
+            document.getElementById('portoneStatus').textContent = '❌ 오류: ' + e.message;
+        }
+    }
+
+    async function verifyIdentityManual() {
+        const impUid = document.getElementById('manualImpUid').value.trim();
+        if (!impUid) { alert('impUid를 입력하세요.'); return; }
+        await callVerifyIdentity(impUid, 'verifyIdentityManual');
+    }
+
+    async function callVerifyIdentity(impUid, resultId) {
+        await api('POST', '/api/auth/verify-identity', { impUid }, resultId, true);
+    }
+
+    // ===================== 섹션 5 =====================
+    async function updateProfile() {
+        const checked = [...document.querySelectorAll('input[name=travelStyle]:checked')];
+        if (checked.length > 3) { alert('여행 스타일은 최대 3개까지 선택 가능합니다.'); return; }
         const body = {
-            password: document.getElementById('updateCurrentPw').value,
-            newPassword: newPw || null,
-            name: document.getElementById('updateName').value || null,
-            gender: document.getElementById('updateGender').value || null,
-            birthDate: document.getElementById('updateBirthDate').value || null
+            nickname: document.getElementById('profileNickname').value || null,
+            bio: document.getElementById('profileBio').value || null,
+            mbti: document.getElementById('profileMbti').value || null,
+            profileImageUrl: document.getElementById('profileImageUrl').value || null,
+            travelStyleIds: checked.map(c => parseInt(c.value))
         };
-        const r = await call('PUT', '/users', body, 'update', true);
-        if (r.ok && r.data?.data?.accessToken) {
-            setTokens(r.data.data.accessToken, null);
+        await api('PUT', '/api/users/profile', body, 'updateProfile', true);
+    }
+
+    async function updateNotification() {
+        const enabled = document.getElementById('notifEnabled').value === 'true';
+        await api('PATCH', '/api/users/notification-settings', { enabled: enabled }, 'notif', true);
+    }
+
+    // ===================== 섹션 6 =====================
+    async function getPresignedUrl() {
+        const ext = document.getElementById('imgExtension').value;
+        const r = await api('POST', '/images/presigned-url', { extension: ext }, 'presigned', true);
+        if (r.ok && r.data?.data) {
+            STATE.presignedUrl = r.data.data.presignedUrl || r.data.data.url;
+            STATE.readImageUrl = r.data.data.readImageUrl;
+            if (STATE.readImageUrl) {
+                document.getElementById('presignedUrlDisplay').style.display = 'block';
+                document.getElementById('readImageUrlVal').textContent = STATE.readImageUrl;
+            }
         }
+    }
+
+    function copyReadUrl() {
+        navigator.clipboard.writeText(STATE.readImageUrl).then(() => alert('복사됨: ' + STATE.readImageUrl));
+    }
+
+    async function uploadToS3() {
+        if (!STATE.presignedUrl) { alert('먼저 Presigned URL을 발급받으세요.'); return; }
+        const file = document.getElementById('uploadFile').files[0];
+        if (!file) { alert('파일을 선택하세요.'); return; }
+        document.getElementById('uploadStatus').textContent = '⏳ 업로드 중...';
+        try {
+            const res = await fetch(STATE.presignedUrl, {
+                method: 'PUT',
+                body: file,
+                headers: { 'Content-Type': file.type }
+            });
+            document.getElementById('uploadStatus').textContent =
+                res.ok ? '✅ 업로드 성공! 위 readImageUrl을 프로필 이미지로 사용하세요.' : '❌ 업로드 실패: ' + res.status;
+        } catch(e) {
+            document.getElementById('uploadStatus').textContent = '❌ 오류: ' + e.message;
+        }
+    }
+
+    // ===================== 섹션 7 =====================
+    async function verifyPassword() {
+        await api('POST', '/users/verify-password', {
+            password: document.getElementById('verifyPwInput').value
+        }, 'verifyPw', true);
     }
 
     async function changePassword() {
-        const body = {
-            currentPassword: document.getElementById('changeCurrent').value,
-            newPassword: document.getElementById('changeNew').value
-        };
-        const r = await call('PATCH', '/users/password', body, 'change', true);
-        if (r.ok && r.data?.data) {
-            setTokens(r.data.data.accessToken, r.data.data.refreshToken);
+        const r = await api('PATCH', '/users/password', {
+            currentPassword: document.getElementById('changePwCurrent').value,
+            newPassword: document.getElementById('changePwNew').value
+        }, 'changePw', true);
+        if (r.ok) {
+            const token = r.data?.data?.accessToken;
+            if (token) setToken(token);
         }
     }
 
+    async function setInitialPassword() {
+        await api('POST', '/users/password', {
+            password: document.getElementById('setInitialPw').value
+        }, 'setInitialPw', true);
+    }
+
+    // ===================== 섹션 8 =====================
+    async function updateUserInfo() {
+        const body = {};
+        const pw = document.getElementById('updatePwCurrent').value;
+        const newPw = document.getElementById('updatePwNew').value;
+        const name = document.getElementById('updateInfoName').value;
+        const gender = document.getElementById('updateInfoGender').value;
+        const birth = document.getElementById('updateInfoBirth').value;
+        if (pw) body.password = pw;
+        if (newPw) body.newPassword = newPw;
+        if (name) body.name = name;
+        if (gender) body.gender = gender;
+        if (birth) body.birthDate = birth;
+        const r = await api('PUT', '/users', body, 'updateInfo', true);
+        if (r.ok) {
+            const token = r.data?.data?.accessToken;
+            if (token) setToken(token);
+        }
+    }
+
+    function toggleDeletePw() {
+        const isSocial = document.getElementById('deleteIsSocial').checked;
+        document.getElementById('deletePwSection').style.display = isSocial ? 'none' : 'block';
+    }
+
+    // ===================== 섹션 9 =====================
+    async function searchByName() {
+        const name = document.getElementById('searchNameInput').value;
+        await api('GET', '/users/search?name=' + encodeURIComponent(name), null, 'searchName', true);
+    }
+
+    async function getMembers() {
+        const ids = document.getElementById('memberIdsInput').value.trim();
+        await api('GET', '/users/members?ids=' + encodeURIComponent(ids), null, 'members', true);
+    }
+
+    // ===================== 섹션 10 =====================
+    async function createTrip() {
+        const body = {
+            tripTitle: document.getElementById('tripTitle').value,
+            tripDescription: document.getElementById('tripDesc').value,
+            startDate: document.getElementById('tripStart').value,
+            endDate: document.getElementById('tripEnd').value,
+            isPublic: document.getElementById('tripPublic').checked
+        };
+        await api('POST', '/trips', body, 'createTrip', true, STATE.tripBase);
+    }
+
+    async function getMyTrips() {
+        await api('GET', '/trips/my', null, 'myTrips', true, STATE.tripBase);
+    }
+
+    // ===================== 섹션 11 =====================
     async function reissue() {
-        // refreshToken은 HttpOnly 쿠키로 자동 전송 (credentials: include)
-        const r = await call('POST', '/auth/reissue', {}, 'reissue', false);
-        if (r.ok && r.data?.data) {
-            setTokens(r.data.data.accessToken, r.data.data.refreshToken);
+        const r = await api('POST', '/auth/reissue', {}, 'reissue', false);
+        if (r.ok) {
+            const token = r.data?.data?.accessToken;
+            if (token) setToken(token);
         }
     }
 
     async function logout() {
-        await call('POST', '/auth/logout', {}, 'logout', true);
+        await api('POST', '/auth/logout', {}, 'logout', true);
         STATE.accessToken = '';
-        STATE.refreshToken = '';
         document.getElementById('tokenBar').style.display = 'none';
     }
 
+    // ===================== 섹션 12 =====================
     async function deleteUser() {
-        const r = await call('DELETE', '/users', {
-            password: document.getElementById('deletePw').value
-        }, 'delete', true);
-        if (r.status === 204) {
+        const isSocial = document.getElementById('deleteIsSocial').checked;
+        const body = isSocial ? {} : { password: document.getElementById('deletePwInput').value };
+        const r = await api('DELETE', '/users', body, 'deleteUser', true);
+        if (r.status === 204 || r.ok) {
             STATE.accessToken = '';
-            STATE.refreshToken = '';
             document.getElementById('tokenBar').style.display = 'none';
         }
     }
 
-    async function searchUsers() {
-        const name = document.getElementById('searchName').value;
-        await call('GET', '/users/search?name=' + encodeURIComponent(name), null, 'search', true);
+    // ===================== 섹션 13: 시나리오 =====================
+    function showScenario(id, pass, msg) {
+        const el = document.getElementById(id);
+        el.style.display = 'block';
+        el.className = 'scenario-result ' + (pass ? 'pass' : 'fail');
+        el.innerHTML = (pass ? '✅ ' : '❌ ') + msg;
+    }
+
+    async function runScenarioA() {
+        const email = document.getElementById('scA_email').value;
+        const pw = document.getElementById('scA_pw').value;
+        const name = document.getElementById('scA_name').value;
+
+        // 1. 회원가입 (닉네임 없이)
+        const r1 = await api('POST', '/users', {
+            email, password: pw, name, gender: 'M', termsAgreed: true, marketingAgreed: false
+        }, null, false);
+        if (!r1.ok) {
+            showScenario('scA_result', false, `회원가입 실패: ${JSON.stringify(r1.data)}`);
+            return;
+        }
+        const token = r1.data?.data?.accessToken || r1.data?.accessToken;
+        if (token) setToken(token);
+
+        // 2. GET /users/me
+        const r2 = await api('GET', '/users/me', null, null, true);
+        if (!r2.ok) {
+            showScenario('scA_result', false, `GET /users/me 실패: ${JSON.stringify(r2.data)}`);
+            return;
+        }
+        const me = r2.data?.data || r2.data;
+        const nicknameMatches = me?.nickname === name;
+        showScenario('scA_result', nicknameMatches,
+            nicknameMatches
+                ? `닉네임 자동 설정 확인 ✅ nickname="${me.nickname}" == name="${name}"`
+                : `닉네임 불일치 ❌ nickname="${me?.nickname}", name="${name}"`
+        );
+    }
+
+    async function runScenarioB() {
+        // 1. 현재 hasPassword 확인
+        const r1 = await api('GET', '/api/users/profile', null, null, true);
+        if (!r1.ok) {
+            showScenario('scB_result', false, `프로필 조회 실패: ${JSON.stringify(r1.data)}`);
+            return;
+        }
+        const profile = r1.data?.data || r1.data;
+        const hasPassword = profile?.hasPassword;
+        let log = `hasPassword=${hasPassword}\n`;
+
+        if (!hasPassword) {
+            // 소셜 전용: POST /users/password → 200 기대
+            const newPw = document.getElementById('scB_newPw').value;
+            const r2 = await api('POST', '/users/password', { newPassword: newPw }, null, true);
+            log += `POST /users/password → ${r2.status} (기대: 200)\n`;
+            const step2Pass = r2.status === 200;
+
+            // PATCH /users/password → 403 기대 (hasPassword가 true가 됐으면 다시 소셜 계정 토큰 필요)
+            // 위 단계에서 hasPassword=true가 됐으므로, 다시 GET으로 확인
+            const r3 = await api('GET', '/api/users/profile', null, null, true);
+            const updated = r3.data?.data || r3.data;
+            log += `비밀번호 설정 후 hasPassword=${updated?.hasPassword}\n`;
+
+            showScenario('scB_result', step2Pass,
+                log + (step2Pass ? '✅ 소셜 유저 최초 비밀번호 설정 성공' : '❌ 실패'));
+        } else {
+            // 이미 비밀번호 있음: POST /users/password → 409 기대
+            const r2 = await api('POST', '/users/password', { newPassword: 'Any1234!' }, null, true);
+            log += `POST /users/password (hasPassword=true) → ${r2.status} (기대: 409)\n`;
+            showScenario('scB_result', r2.status === 409,
+                log + (r2.status === 409 ? '✅ Member-008 확인' : `❌ 기대: 409, 실제: ${r2.status}`));
+        }
+    }
+
+    async function runScenarioC() {
+        // 1. isVerified 확인
+        const r1 = await api('GET', '/users/me', null, null, true);
+        if (!r1.ok) {
+            showScenario('scC_result', false, `GET /users/me 실패`);
+            return;
+        }
+        const me = r1.data?.data || r1.data;
+        const isVerified = me?.isVerified;
+        let log = `isVerified=${isVerified}\n`;
+
+        if (!isVerified) {
+            showScenario('scC_result', false, log + '본인인증이 완료되지 않았습니다. 섹션 4에서 본인인증 후 재시도하세요.');
+            return;
+        }
+
+        const pw = document.getElementById('scC_pw').value;
+        const body1 = { name: '변경시도' };
+        if (pw) body1.password = pw;
+
+        // 이름 변경 → 400 기대
+        const r2 = await api('PUT', '/users', body1, null, true);
+        log += `PUT /users {name: "변경시도"} → ${r2.status} (기대: 400)\n`;
+        const step2Pass = r2.status === 400;
+
+        // 성별 변경 → 200 기대
+        const body2 = { gender: me?.gender === 'M' ? 'F' : 'M' };
+        if (pw) body2.password = pw;
+        const r3 = await api('PUT', '/users', body2, null, true);
+        log += `PUT /users {gender: "${body2.gender}"} → ${r3.status} (기대: 200)\n`;
+        const step3Pass = r3.status === 200;
+
+        showScenario('scC_result', step2Pass && step3Pass,
+            log + (step2Pass && step3Pass ? '✅ isVerified 잠금 정상 동작' : '❌ 예상과 다른 응답'));
+    }
+
+    async function runScenarioD() {
+        const r = await api('GET', '/api/users/profile', null, null, true);
+        if (!r.ok) {
+            showScenario('scD_result', false, `프로필 조회 실패: ${JSON.stringify(r.data)}`);
+            return;
+        }
+        const profile = r.data?.data || r.data;
+        const linked = profile?.linkedProviders || [];
+        const hasLinked = linked.length > 0;
+        const providers = linked.map(p => p.provider).join(', ');
+        showScenario('scD_result', hasLinked,
+            hasLinked
+                ? `linkedProviders: [${providers}] (${linked.length}개 연동됨) ✅`
+                : `linkedProviders가 비어있습니다. 소셜 로그인 후 재시도하세요.`
+        );
+    }
+
+    async function runScenarioE() {
+        // 1. hasPassword 확인
+        const r1 = await api('GET', '/users/me', null, null, true);
+        if (!r1.ok) {
+            showScenario('scE_result', false, 'GET /users/me 실패');
+            return;
+        }
+        const me = r1.data?.data || r1.data;
+        let log = `hasPassword=${me?.hasPassword}, 탈퇴 시도...\n`;
+
+        // 2. DELETE /users (body 없이)
+        const r2 = await api('DELETE', '/users', {}, null, true);
+        log += `DELETE /users → ${r2.status} (기대: 204)\n`;
+        if (r2.status !== 204) {
+            showScenario('scE_result', false, log + `❌ 탈퇴 실패`);
+            return;
+        }
+        STATE.accessToken = '';
+        document.getElementById('tokenBar').style.display = 'none';
+
+        // 3. 재가입 시도
+        const email = document.getElementById('scE_email').value || me?.email;
+        if (!email) {
+            showScenario('scE_result', true, log + `✅ 탈퇴 성공. 재가입 이메일 입력 후 재시도 가능.`);
+            return;
+        }
+        const r3 = await api('POST', '/users', {
+            email, password: 'AnyPw1234!', name: '재가입', gender: 'M', termsAgreed: true, marketingAgreed: false
+        }, null, false);
+        log += `POST /users (재가입) → ${r3.status} (기대: 400 Member-003)\n`;
+        const step3Pass = r3.status === 400;
+        showScenario('scE_result', step3Pass,
+            log + (step3Pass ? '✅ 탈퇴 계정 재가입 차단 확인 (Member-003)' : `❌ 기대: 400, 실제: ${r3.status}`));
     }
 </script>
 </body>

--- a/src/main/resources/test.html
+++ b/src/main/resources/test.html
@@ -3,189 +3,366 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ReTrip 통합 테스트 (V3)</title>
-
-    <script src="https://cdn.portone.io/v2/browser-sdk.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
-
+    <title>ReTrip Auth API 통합 테스트</title>
     <style>
-        body { font-family: 'Segoe UI', sans-serif; max-width: 900px; margin: 30px auto; padding: 20px; background: #f0f2f5; }
-        .container { background: white; border-radius: 10px; padding: 30px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
-        .section { background: #fff; padding: 20px; margin-bottom: 20px; border: 1px solid #ddd; border-radius: 8px; border-left: 5px solid #667eea; }
-        h1 { text-align: center; color: #333; }
-        h3 { margin-top: 0; color: #444; }
-        input, select, textarea { width: 100%; padding: 10px; margin: 5px 0 15px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
-        button { background: #667eea; color: white; border: none; padding: 12px 20px; border-radius: 4px; cursor: pointer; font-weight: bold; width: 100%; }
-        button:disabled { background: #ccc; cursor: not-allowed; }
-        button:hover:not(:disabled) { background: #5a6fd6; }
-        .result { background: #2d2d2d; color: #50ff50; padding: 15px; margin-top: 10px; border-radius: 4px; font-family: monospace; white-space: pre-wrap; font-size: 13px; display: none; }
-        .error { color: #ff5050; }
-        .checkbox-group { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 15px; }
-        .checkbox-group label { display: flex; align-items: center; background: #eee; padding: 5px 10px; border-radius: 20px; cursor: pointer; font-size: 13px; }
-        .checkbox-group input { width: auto; margin-right: 5px; }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: 'Segoe UI', sans-serif; background: #f0f2f5; padding: 20px; }
+        .page-title { text-align: center; color: #2c3e50; margin: 20px 0 30px; font-size: 24px; font-weight: 700; }
+        .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(420px, 1fr)); gap: 20px; max-width: 1400px; margin: 0 auto; }
+        .card { background: white; border-radius: 10px; padding: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); border-top: 4px solid #667eea; }
+        .card h3 { color: #2c3e50; font-size: 15px; margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
+        .card h3 .badge { background: #667eea; color: white; font-size: 11px; padding: 2px 8px; border-radius: 10px; font-weight: 600; }
+        label { display: block; font-size: 12px; color: #666; margin-bottom: 3px; margin-top: 10px; }
+        input, select { width: 100%; padding: 8px 10px; border: 1px solid #ddd; border-radius: 5px; font-size: 13px; }
+        input:focus, select:focus { outline: none; border-color: #667eea; box-shadow: 0 0 0 2px rgba(102,126,234,0.2); }
+        .btn { margin-top: 14px; width: 100%; padding: 10px; border: none; border-radius: 5px; cursor: pointer; font-size: 14px; font-weight: 600; transition: opacity 0.2s; }
+        .btn:hover { opacity: 0.85; }
+        .btn-primary { background: #667eea; color: white; }
+        .btn-danger { background: #e74c3c; color: white; }
+        .btn-success { background: #27ae60; color: white; }
+        .btn-warning { background: #f39c12; color: white; }
+        .result-box { margin-top: 12px; background: #1e1e2e; border-radius: 6px; overflow: hidden; display: none; }
+        .result-header { display: flex; justify-content: space-between; align-items: center; padding: 6px 12px; background: #2d2d44; font-size: 12px; }
+        .result-header .status { font-weight: 700; }
+        .status-ok { color: #50fa7b; }
+        .status-err { color: #ff5555; }
+        .result-body { padding: 10px 12px; color: #cdd6f4; font-family: monospace; font-size: 12px; white-space: pre-wrap; word-break: break-all; max-height: 220px; overflow-y: auto; }
+        .token-display { background: #eef2ff; border: 1px solid #c7d2fe; border-radius: 6px; padding: 10px 12px; font-family: monospace; font-size: 11px; word-break: break-all; color: #4338ca; margin-top: 8px; display: none; }
+        .config-bar { background: white; border-radius: 8px; padding: 16px 20px; max-width: 1400px; margin: 0 auto 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+        .config-bar label { margin: 0; font-size: 12px; color: #666; white-space: nowrap; }
+        .config-bar input { width: 240px; }
+        .config-bar .btn { width: auto; padding: 8px 18px; margin: 0; }
+        .token-bar { background: #eef2ff; border-radius: 8px; padding: 12px 20px; max-width: 1400px; margin: 0 auto 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); font-size: 12px; color: #4338ca; font-family: monospace; display: none; }
+        .token-bar strong { color: #312e81; }
+        .divider { max-width: 1400px; margin: 0 auto 16px; display: flex; align-items: center; gap: 10px; color: #999; font-size: 13px; font-weight: 600; }
+        .divider::before, .divider::after { content: ''; flex: 1; height: 1px; background: #ddd; }
     </style>
 </head>
 <body>
-<div class="container">
-    <h1>ReTrip 기능 테스트</h1>
+<h1 class="page-title">ReTrip Auth API 통합 테스트</h1>
 
-    <div class="section">
-        <h3>⚙️ Step 0: PortOne 설정</h3>
-        <input type="text" id="storeId" placeholder="Store ID 입력">
-        <input type="text" id="channelKey" placeholder="Channel Key 입력">
-        <button onclick="saveConfig()">설정 저장</button>
-    </div>
+<!-- 설정 바 -->
+<div class="config-bar">
+    <label>Auth Server</label>
+    <input type="text" id="apiBase" value="http://localhost:8080" style="width:220px;">
+    <label style="margin-left:10px;">Trip Server</label>
+    <input type="text" id="tripBase" value="http://localhost:8081" style="width:220px;">
+    <button class="btn btn-primary" onclick="saveConfig()" style="width:auto;padding:8px 18px;margin:0;">설정 저장</button>
+    <span id="configStatus" style="font-size:12px;color:#27ae60;display:none;">✓ 저장됨</span>
+</div>
 
-    <div class="section">
-        <h3>👤 Step 1: 회원가입</h3>
-        <input type="email" id="signupEmail" value="user@test.com" placeholder="이메일">
-        <input type="password" id="signupPassword" value="1234" placeholder="비밀번호">
-        <input type="text" id="signupName" value="테스트유저" placeholder="이름">
-        <div style="display: flex; gap: 10px;">
-            <select id="signupGender"><option value="M">남성</option><option value="F">여성</option></select>
-            <input type="number" id="signupAge" value="25" placeholder="나이">
+<!-- 현재 토큰 표시 바 -->
+<div class="token-bar" id="tokenBar">
+    <strong>현재 Access Token:</strong> <span id="tokenPreview"></span>
+</div>
+
+<div class="grid">
+
+    <!-- 1. 회원가입 -->
+    <div class="card">
+        <h3><span class="badge">POST /users</span> 회원가입</h3>
+        <label>이메일</label>
+        <input type="email" id="signupEmail" value="user@test.com">
+        <label>비밀번호 (영문+숫자+특수문자 8~20자)</label>
+        <input type="password" id="signupPassword" value="Test1234!">
+        <label>이름</label>
+        <input type="text" id="signupName" value="테스트유저">
+        <label>닉네임 (선택, 최대 15자)</label>
+        <input type="text" id="signupNickname" placeholder="미입력 시 이름으로 설정">
+        <label>성별</label>
+        <select id="signupGender"><option value="M">남성</option><option value="F">여성</option></select>
+        <label>생년월일 (YYYY-MM-DD, 선택)</label>
+        <input type="text" id="signupBirthDate" placeholder="예: 1995-01-01">
+        <label><input type="checkbox" id="signupTerms" checked style="width:auto;margin-right:5px;">필수 약관 동의</label>
+        <label><input type="checkbox" id="signupMarketing" style="width:auto;margin-right:5px;">마케팅 수신 동의</label>
+        <button class="btn btn-primary" onclick="signup()">회원가입</button>
+        <div class="result-box" id="signupResult">
+            <div class="result-header"><span class="status" id="signupStatus"></span><span>Response</span></div>
+            <div class="result-body" id="signupBody"></div>
         </div>
-        <button onclick="signup()">회원가입</button>
-        <div id="signupResult" class="result"></div>
     </div>
 
-    <div class="section">
-        <h3>🔐 Step 2: 로그인</h3>
-        <button onclick="login()">로그인 (Step 1 정보로)</button>
-        <div id="loginResult" class="result"></div>
-    </div>
-
-    <div class="section">
-        <h3>✨ Step 3: 본인인증 (PortOne V2)</h3>
-        <button id="certBtn" onclick="startCertificationV2()" disabled>본인인증 시작</button>
-        <div id="certResult" class="result"></div>
-    </div>
-
-    <div class="section">
-        <h3>📋 Step 4: 내 프로필 조회</h3>
-        <button id="profileBtn" onclick="getProfile()" disabled>프로필 조회</button>
-        <div id="profileResult" class="result"></div>
-    </div>
-
-    <div class="section">
-        <h3>✏️ Step 5: 프로필 수정 (추가 정보)</h3>
-        <textarea id="updateBio" placeholder="한 줄 소개 (최대 30자)" rows="2">여행을 좋아하는 개발자입니다.</textarea>
-        <select id="updateMbti">
-            <option value="">MBTI 선택</option>
-            <option value="ISTJ">ISTJ</option> <option value="ISFJ">ISFJ</option>
-            <option value="INFJ">INFJ</option> <option value="INTJ">INTJ</option>
-            <option value="ISTP">ISTP</option> <option value="ISFP">ISFP</option>
-            <option value="INFP">INFP</option> <option value="INTP">INTP</option>
-            <option value="ESTP">ESTP</option> <option value="ESFP">ESFP</option>
-            <option value="ENFP">ENFP</option> <option value="ENTP">ENTP</option>
-            <option value="ESTJ">ESTJ</option> <option value="ESFJ">ESFJ</option>
-            <option value="ENFJ">ENFJ</option> <option value="ENTJ">ENTJ</option>
-        </select>
-        <div class="checkbox-group">
-            <label><input type="checkbox" name="styles" value="계획철저"> 계획철저</label>
-            <label><input type="checkbox" name="styles" value="즉흥적"> 즉흥적</label>
-            <label><input type="checkbox" name="styles" value="맛집탐방"> 맛집탐방</label>
-            <label><input type="checkbox" name="styles" value="휴양지"> 휴양지</label>
-            <label><input type="checkbox" name="styles" value="가성비"> 가성비</label>
-            <label><input type="checkbox" name="styles" value="플렉스"> 플렉스</label>
+    <!-- 2. 로그인 -->
+    <div class="card">
+        <h3><span class="badge">POST /login</span> 로그인</h3>
+        <label>이메일 (id 필드)</label>
+        <input type="email" id="loginEmail" value="user@test.com">
+        <label>비밀번호</label>
+        <input type="password" id="loginPassword" value="Test1234!">
+        <button class="btn btn-primary" onclick="login()">로그인</button>
+        <div id="loginTokenDisplay" class="token-display"></div>
+        <div class="result-box" id="loginResult">
+            <div class="result-header"><span class="status" id="loginStatus"></span><span>Response</span></div>
+            <div class="result-body" id="loginBody"></div>
         </div>
-        <button id="updateBtn" onclick="updateProfile()" disabled>정보 수정 저장</button>
-        <div id="updateResult" class="result"></div>
     </div>
+
+    <!-- 3. 내 정보 조회 -->
+    <div class="card">
+        <h3><span class="badge">GET /users/me</span> 내 정보 조회</h3>
+        <p style="font-size:12px;color:#888;margin-bottom:8px;">로그인 후 자동으로 토큰 사용</p>
+        <button class="btn btn-success" onclick="getMe()">내 정보 조회</button>
+        <div class="result-box" id="meResult">
+            <div class="result-header"><span class="status" id="meStatus"></span><span>Response</span></div>
+            <div class="result-body" id="meBody"></div>
+        </div>
+    </div>
+
+    <!-- 4. 비밀번호 확인 -->
+    <div class="card">
+        <h3><span class="badge">POST /users/verify-password</span> 비밀번호 확인</h3>
+        <label>비밀번호 입력</label>
+        <input type="password" id="verifyPw" value="Test1234!">
+        <button class="btn btn-warning" onclick="verifyPassword()">비밀번호 확인</button>
+        <div class="result-box" id="verifyResult">
+            <div class="result-header"><span class="status" id="verifyStatus"></span><span>Response</span></div>
+            <div class="result-body" id="verifyBody"></div>
+        </div>
+    </div>
+
+    <!-- 5. 회원정보 수정 -->
+    <div class="card">
+        <h3><span class="badge">PUT /users</span> 회원정보 수정</h3>
+        <label>현재 비밀번호</label>
+        <input type="password" id="updateCurrentPw" value="Test1234!">
+        <label>새 비밀번호 (변경 시, 빈칸이면 유지)</label>
+        <input type="password" id="updateNewPw" placeholder="빈칸이면 변경 안 함">
+        <label>이름</label>
+        <input type="text" id="updateName" value="수정된이름">
+        <label>성별</label>
+        <select id="updateGender"><option value="M">남성</option><option value="F">여성</option></select>
+        <label>생년월일</label>
+        <input type="text" id="updateBirthDate" placeholder="예: 1995-06-15">
+        <button class="btn btn-warning" onclick="updateUser()">정보 수정</button>
+        <div class="result-box" id="updateResult">
+            <div class="result-header"><span class="status" id="updateStatus"></span><span>Response</span></div>
+            <div class="result-body" id="updateBody"></div>
+        </div>
+    </div>
+
+    <!-- 6. 비밀번호 변경 -->
+    <div class="card">
+        <h3><span class="badge">PATCH /users/password</span> 비밀번호 변경</h3>
+        <label>현재 비밀번호</label>
+        <input type="password" id="changeCurrent" value="Test1234!">
+        <label>새 비밀번호</label>
+        <input type="password" id="changeNew" value="NewPass1234!">
+        <button class="btn btn-warning" onclick="changePassword()">비밀번호 변경</button>
+        <div class="result-box" id="changeResult">
+            <div class="result-header"><span class="status" id="changeStatus"></span><span>Response</span></div>
+            <div class="result-body" id="changeBody"></div>
+        </div>
+    </div>
+
+    <!-- 7. 토큰 재발급 -->
+    <div class="card">
+        <h3><span class="badge">POST /auth/reissue</span> 토큰 재발급</h3>
+        <p style="font-size:12px;color:#888;margin-bottom:8px;">저장된 refreshToken 쿠키로 재발급합니다.</p>
+        <label>현재 Refresh Token</label>
+        <input type="text" id="reissueToken" placeholder="로그인 후 자동 설정됨">
+        <button class="btn btn-success" onclick="reissue()">재발급</button>
+        <div class="result-box" id="reissueResult">
+            <div class="result-header"><span class="status" id="reissueStatus"></span><span>Response</span></div>
+            <div class="result-body" id="reissueBody"></div>
+        </div>
+    </div>
+
+    <!-- 8. 로그아웃 -->
+    <div class="card">
+        <h3><span class="badge">POST /auth/logout</span> 로그아웃</h3>
+        <p style="font-size:12px;color:#888;margin-bottom:8px;">refreshToken 쿠키를 만료 처리합니다.</p>
+        <button class="btn btn-danger" onclick="logout()">로그아웃</button>
+        <div class="result-box" id="logoutResult">
+            <div class="result-header"><span class="status" id="logoutStatus"></span><span>Response</span></div>
+            <div class="result-body" id="logoutBody"></div>
+        </div>
+    </div>
+
+    <!-- 9. 회원탈퇴 -->
+    <div class="card">
+        <h3><span class="badge">DELETE /users</span> 회원탈퇴</h3>
+        <label>비밀번호 확인</label>
+        <input type="password" id="deletePw" value="Test1234!">
+        <button class="btn btn-danger" onclick="deleteUser()">회원탈퇴</button>
+        <div class="result-box" id="deleteResult">
+            <div class="result-header"><span class="status" id="deleteStatus"></span><span>Response</span></div>
+            <div class="result-body" id="deleteBody"></div>
+        </div>
+    </div>
+
+    <!-- 10. 이름 검색 -->
+    <div class="card">
+        <h3><span class="badge">GET /users/search</span> 이름으로 회원 검색</h3>
+        <label>이름 (부분 일치)</label>
+        <input type="text" id="searchName" value="테스트">
+        <button class="btn btn-success" onclick="searchUsers()">검색</button>
+        <div class="result-box" id="searchResult">
+            <div class="result-header"><span class="status" id="searchStatus"></span><span>Response</span></div>
+            <div class="result-body" id="searchBody"></div>
+        </div>
+    </div>
+
 </div>
 
 <script>
-    const API_BASE = 'http://localhost:8080';
-    let CONFIG = { storeId: '', channelKey: '', accessToken: '' };
+    let STATE = {
+        apiBase: 'http://localhost:8080',
+        tripBase: 'http://localhost:8081',
+        accessToken: '',
+        refreshToken: ''
+    };
 
     function saveConfig() {
-        CONFIG.storeId = document.getElementById('storeId').value;
-        CONFIG.channelKey = document.getElementById('channelKey').value;
-        alert('설정 저장됨');
+        STATE.apiBase = document.getElementById('apiBase').value.replace(/\/$/, '');
+        STATE.tripBase = document.getElementById('tripBase').value.replace(/\/$/, '');
+        const s = document.getElementById('configStatus');
+        s.style.display = 'inline';
+        setTimeout(() => s.style.display = 'none', 2000);
+    }
+
+    function setTokens(access, refresh) {
+        STATE.accessToken = access || STATE.accessToken;
+        STATE.refreshToken = refresh || STATE.refreshToken;
+        if (STATE.accessToken) {
+            const bar = document.getElementById('tokenBar');
+            bar.style.display = 'block';
+            document.getElementById('tokenPreview').textContent = STATE.accessToken.substring(0, 40) + '...';
+            document.getElementById('loginTokenDisplay').style.display = 'block';
+            document.getElementById('loginTokenDisplay').textContent =
+                'Access:  ' + STATE.accessToken.substring(0, 50) + '...\nRefresh: ' + (STATE.refreshToken || '(쿠키에 저장됨)').substring(0, 50);
+            if (STATE.refreshToken) {
+                document.getElementById('reissueToken').value = STATE.refreshToken;
+            }
+        }
+    }
+
+    function show(id, status, body, isError) {
+        const box = document.getElementById(id + 'Result');
+        box.style.display = 'block';
+        const st = document.getElementById(id + 'Status');
+        st.textContent = status;
+        st.className = 'status ' + (isError ? 'status-err' : 'status-ok');
+        document.getElementById(id + 'Body').textContent =
+            typeof body === 'object' ? JSON.stringify(body, null, 2) : body;
+    }
+
+    async function call(method, path, body, resultId, useToken) {
+        const url = STATE.apiBase + path;
+        const headers = { 'Content-Type': 'application/json' };
+        if (useToken && STATE.accessToken) {
+            headers['Authorization'] = 'Bearer ' + STATE.accessToken;
+        }
+        try {
+            const opts = { method, headers, credentials: 'include' };
+            if (body !== null) opts.body = JSON.stringify(body);
+            const res = await fetch(url, opts);
+            const text = await res.text();
+            let parsed;
+            try { parsed = JSON.parse(text); } catch { parsed = text; }
+            const isError = !res.ok;
+            show(resultId, res.status + ' ' + (isError ? '❌' : '✅'), parsed, isError);
+            return { ok: !isError, status: res.status, data: parsed };
+        } catch (e) {
+            show(resultId, '네트워크 오류 ❌', e.message, true);
+            return { ok: false };
+        }
     }
 
     async function signup() {
-        try {
-            const res = await axios.post(`${API_BASE}/users`, {
-                email: document.getElementById('signupEmail').value,
-                password: document.getElementById('signupPassword').value,
-                name: document.getElementById('signupName').value,
-                gender: document.getElementById('signupGender').value,
-                age: parseInt(document.getElementById('signupAge').value)
-            });
-            showResult('signupResult', '✅ 가입 성공! accessToken 자동 발급됨.');
-            CONFIG.accessToken = res.data.data.accessToken;
-            enableButtons();
-        } catch (e) { showResult('signupResult', e.response?.data?.message || e.message, true); }
+        const body = {
+            email: document.getElementById('signupEmail').value,
+            password: document.getElementById('signupPassword').value,
+            name: document.getElementById('signupName').value,
+            nickname: document.getElementById('signupNickname').value || null,
+            gender: document.getElementById('signupGender').value,
+            birthDate: document.getElementById('signupBirthDate').value || null,
+            termsAgreed: document.getElementById('signupTerms').checked,
+            marketingAgreed: document.getElementById('signupMarketing').checked
+        };
+        const r = await call('POST', '/users', body, 'signup', false);
+        if (r.ok && r.data?.data) {
+            setTokens(r.data.data.accessToken, r.data.data.refreshToken);
+            document.getElementById('loginEmail').value = body.email;
+            document.getElementById('loginPassword').value = body.password;
+        }
     }
 
     async function login() {
-        try {
-            const res = await axios.post(`${API_BASE}/login`, {
-                id: document.getElementById('signupEmail').value,
-                password: document.getElementById('signupPassword').value
-            });
-            CONFIG.accessToken = res.data.data.accessToken;
-            showResult('loginResult', `✅ 로그인 성공\nToken: ${CONFIG.accessToken.substring(0,20)}...`);
-            enableButtons();
-        } catch (e) { showResult('loginResult', e.response?.data?.message || e.message, true); }
+        const body = {
+            id: document.getElementById('loginEmail').value,
+            password: document.getElementById('loginPassword').value
+        };
+        const r = await call('POST', '/login', body, 'login', false);
+        if (r.ok && r.data?.data) {
+            setTokens(r.data.data.accessToken, r.data.data.refreshToken);
+        }
     }
 
-    async function startCertificationV2() {
-        if (!CONFIG.storeId) return alert('Step 0 설정을 먼저 해주세요.');
-        try {
-            const response = await PortOne.requestIdentityVerification({
-                storeId: CONFIG.storeId,
-                identityVerificationId: `identity_${Date.now()}`,
-                channelKey: CONFIG.channelKey,
-            });
-            if (response.code) throw new Error(response.message);
-
-            const verifyRes = await axios.post(`${API_BASE}/api/auth/verify-identity`,
-                { impUid: response.identityVerificationId },
-                { headers: { 'Authorization': `Bearer ${CONFIG.accessToken}` } }
-            );
-
-            const d = verifyRes.data.data;
-            showResult('certResult', `✅ 인증 완료\n이름: ${d.name}, 성별: ${d.gender}, 나이: ${d.age}, 인증여부: ${d.isVerified}`);
-        } catch (e) { showResult('certResult', e.message, true); }
+    async function getMe() {
+        await call('GET', '/users/me', null, 'me', true);
     }
 
-    async function getProfile() {
-        try {
-            const res = await axios.get(`${API_BASE}/api/users/profile`, {
-                headers: { 'Authorization': `Bearer ${CONFIG.accessToken}` }
-            });
-            const d = res.data.data;
-            showResult('profileResult', `📋 프로필\n이메일: ${d.email}\n이름: ${d.name} (${d.age}세/${d.gender})\n본인인증: ${d.isVerified}\n소개: ${d.bio}\nMBTI: ${d.mbti}\n스타일: ${d.travelStyles?.join(', ')}`);
-        } catch (e) { showResult('profileResult', e.message, true); }
+    async function verifyPassword() {
+        await call('POST', '/users/verify-password', {
+            password: document.getElementById('verifyPw').value
+        }, 'verify', true);
     }
 
-    async function updateProfile() {
-        const styles = Array.from(document.querySelectorAll('input[name="styles"]:checked')).map(cb => cb.value);
-        try {
-            const res = await axios.put(`${API_BASE}/api/users/profile`, {
-                bio: document.getElementById('updateBio').value,
-                mbti: document.getElementById('updateMbti').value,
-                travelStyles: styles
-            }, { headers: { 'Authorization': `Bearer ${CONFIG.accessToken}` } });
-
-            const d = res.data.data;
-            showResult('updateResult', `✅ 수정 완료\n소개: ${d.bio}\nMBTI: ${d.mbti}\n스타일: ${d.travelStyles?.join(', ')}`);
-            // 프로필 다시 조회하여 갱신 확인
-            getProfile();
-        } catch (e) { showResult('updateResult', e.response?.data?.message || e.message, true); }
+    async function updateUser() {
+        const newPw = document.getElementById('updateNewPw').value;
+        const body = {
+            password: document.getElementById('updateCurrentPw').value,
+            newPassword: newPw || null,
+            name: document.getElementById('updateName').value || null,
+            gender: document.getElementById('updateGender').value || null,
+            birthDate: document.getElementById('updateBirthDate').value || null
+        };
+        const r = await call('PUT', '/users', body, 'update', true);
+        if (r.ok && r.data?.data?.accessToken) {
+            setTokens(r.data.data.accessToken, null);
+        }
     }
 
-    function showResult(id, msg, isError = false) {
-        const el = document.getElementById(id);
-        el.style.display = 'block';
-        el.className = isError ? 'result error' : 'result';
-        el.innerText = msg;
+    async function changePassword() {
+        const body = {
+            currentPassword: document.getElementById('changeCurrent').value,
+            newPassword: document.getElementById('changeNew').value
+        };
+        const r = await call('PATCH', '/users/password', body, 'change', true);
+        if (r.ok && r.data?.data) {
+            setTokens(r.data.data.accessToken, r.data.data.refreshToken);
+        }
     }
 
-    function enableButtons() {
-        ['certBtn', 'profileBtn', 'updateBtn'].forEach(id => document.getElementById(id).disabled = false);
+    async function reissue() {
+        // refreshToken은 HttpOnly 쿠키로 자동 전송 (credentials: include)
+        const r = await call('POST', '/auth/reissue', {}, 'reissue', false);
+        if (r.ok && r.data?.data) {
+            setTokens(r.data.data.accessToken, r.data.data.refreshToken);
+        }
+    }
+
+    async function logout() {
+        await call('POST', '/auth/logout', {}, 'logout', true);
+        STATE.accessToken = '';
+        STATE.refreshToken = '';
+        document.getElementById('tokenBar').style.display = 'none';
+    }
+
+    async function deleteUser() {
+        const r = await call('DELETE', '/users', {
+            password: document.getElementById('deletePw').value
+        }, 'delete', true);
+        if (r.status === 204) {
+            STATE.accessToken = '';
+            STATE.refreshToken = '';
+            document.getElementById('tokenBar').style.display = 'none';
+        }
+    }
+
+    async function searchUsers() {
+        const name = document.getElementById('searchName').value;
+        await call('GET', '/users/search?name=' + encodeURIComponent(name), null, 'search', true);
     }
 </script>
 </body>

--- a/src/test/java/com/retrip/auth/application/in/AuthServiceTest.java
+++ b/src/test/java/com/retrip/auth/application/in/AuthServiceTest.java
@@ -2,7 +2,9 @@ package com.retrip.auth.application.in;
 
 import com.retrip.auth.application.config.JwtProvider;
 import com.retrip.auth.application.in.response.LoginResponse;
+import com.retrip.auth.application.out.repository.MemberRepository;
 import com.retrip.auth.application.out.repository.RefreshTokenRepository;
+import com.retrip.auth.domain.entity.Member;
 import com.retrip.auth.domain.entity.RefreshToken;
 import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.DisplayName;
@@ -33,24 +35,30 @@ class AuthServiceTest {
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
 
+    @Mock
+    private MemberRepository memberRepository;
+
     @Test
     @DisplayName("토큰 재발급(reissue) 성공 테스트")
     void reissue_Success() {
         // given
         String oldRefreshToken = "old-refresh-token";
-        String memberId = "test-uuid";
+        String memberId = "00000000-0000-0000-0000-000000000001";
         String authorities = "ROLE_USER";
 
         given(jwtProvider.validateToken(oldRefreshToken)).willReturn(true);
 
         RefreshToken savedToken = new RefreshToken(oldRefreshToken, memberId, authorities);
-        given(refreshTokenRepository.findById(oldRefreshToken)).willReturn(Optional.of(savedToken));
+        given(refreshTokenRepository.findByTokenValue(oldRefreshToken)).willReturn(Optional.of(savedToken));
 
         Claims claims = mock(Claims.class);
         given(claims.getSubject()).willReturn(memberId);
-        given(claims.get("authorities")).willReturn(authorities);
 
         given(jwtProvider.parseClaims(oldRefreshToken)).willReturn(claims);
+
+        Member mockMember = mock(Member.class);
+        given(mockMember.getIsDeleted()).willReturn(false);
+        given(memberRepository.findById(any())).willReturn(Optional.of(mockMember));
 
         LoginResponse.TokenResponse newTokens = new LoginResponse.TokenResponse("new-access", "new-refresh");
         given(jwtProvider.generateTokens(any(Authentication.class))).willReturn(newTokens);

--- a/src/test/java/com/retrip/auth/application/in/MemberServiceTest.java
+++ b/src/test/java/com/retrip/auth/application/in/MemberServiceTest.java
@@ -23,7 +23,7 @@ class MemberServiceTest extends BaseMemberServiceTest {
     @Test
     void 회원가입_성공() throws Exception {
         // given
-        MemberCreateRequest request = new MemberCreateRequest("test@naver.com", "1234", "test", null, null, true, false);
+        MemberCreateRequest request = new MemberCreateRequest("test@naver.com", "1234", "test", null, null, null, true, false);
 
         //when
         MemberCreateResponse response = memberService.createUser(request);
@@ -37,8 +37,8 @@ class MemberServiceTest extends BaseMemberServiceTest {
     @Test
     void 회원가입_중복_회원가입() throws Exception {
         // given
-        memberRepository.save(Member.create("test", "test@naver.com", passwordEncoder.encode("1234"), List.of("user"), null, null, true, false));
-        MemberCreateRequest request = new MemberCreateRequest("test@naver.com", "1111", "중복 테스트", null, null, true, false);
+        memberRepository.save(Member.create("test", "test@naver.com", passwordEncoder.encode("1234"), List.of("user"), null, null, true, false, null));
+        MemberCreateRequest request = new MemberCreateRequest("test@naver.com", "1111", "중복 테스트", null, null, null, true, false);
 
         //when
 
@@ -52,7 +52,7 @@ class MemberServiceTest extends BaseMemberServiceTest {
     @Test
     void 회원정보_수정_패스워드_달라_실패() throws Exception {
         // given
-        Member saved = memberRepository.save(Member.create("test", "test@naver.com", passwordEncoder.encode("1234"), List.of("user"), null, null, true, false));
+        Member saved = memberRepository.save(Member.create("test", "test@naver.com", passwordEncoder.encode("1234"), List.of("user"), null, null, true, false, null));
         MemberUpdateRequest request = new MemberUpdateRequest("1235", "1111", "수정 테스트", null, null);
 
         //when
@@ -79,7 +79,7 @@ class MemberServiceTest extends BaseMemberServiceTest {
     @Test
     void 회원정보_수정_성공() throws Exception {
         // given
-        Member saved = memberRepository.save(Member.create("test", "test@naver.com", passwordEncoder.encode("1234"), List.of("user"), null, null, true, false));
+        Member saved = memberRepository.save(Member.create("test", "test@naver.com", passwordEncoder.encode("1234"), List.of("user"), null, null, true, false, null));
         MemberUpdateRequest request = new MemberUpdateRequest("1234", "1111", "수정 테스트", null, null);
 
         //when

--- a/src/test/java/com/retrip/auth/infra/adapter/in/rest/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/retrip/auth/infra/adapter/in/rest/filter/JwtAuthenticationFilterTest.java
@@ -2,6 +2,7 @@ package com.retrip.auth.infra.adapter.in.rest.filter;
 
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -16,8 +17,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Transactional
 @AutoConfigureMockMvc(addFilters = true)
 class JwtAuthenticationFilterTest extends BaseLoginAuthenticationTest {
 
@@ -28,37 +31,24 @@ class JwtAuthenticationFilterTest extends BaseLoginAuthenticationTest {
     void JwtLogin() throws Exception {
         memberRepository.save(member);
 
-        // given
+        // 로그인으로 JWT 발급
         LoginRequest request = new LoginRequest("test@naver.com", "1234");
-
-        //when
-        // headers 생성
-        HttpHeaders loginHeader = new HttpHeaders();
-        loginHeader.add("id", request.id());
-        loginHeader.add("password", request.password());
-        MvcResult mvcResult =  mockMvc.perform(get("/login")
+        String loginJson = new ObjectMapper().writeValueAsString(request);
+        MvcResult mvcResult = mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .headers(loginHeader))
+                        .content(loginJson))
                 .andExpect(status().isOk())
-                .andReturn(); //로그인 결과
-        // 응답 본문 추출
-        String responseBody = mvcResult.getResponse().getContentAsString();
+                .andReturn();
 
-        // JSON 파싱
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(responseBody);
-        JsonNode data = jsonNode.get("data");
+        // 토큰 추출
+        JsonNode data = new ObjectMapper().readTree(mvcResult.getResponse().getContentAsString()).get("data");
         String accessToken = data.get("accessToken").asText();
-        String refreshToken = data.get("refreshToken").asText();
 
-
-        // when & then
-        HttpHeaders jwtHeader = new HttpHeaders();
-        jwtHeader.add("Authorization", "Bearer " + accessToken);
-        mockMvc.perform(get("/test")
+        // JWT로 보호된 엔드포인트 호출 (GET /users/me)
+        mockMvc.perform(get("/users/me")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .headers(jwtHeader))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isOk())
-                .andExpect(content().string("test@naver.com"));
+                .andExpect(jsonPath("$.data.email").value("test@naver.com"));
     }
 }

--- a/src/test/java/com/retrip/auth/infra/adapter/in/rest/filter/LoginAuthenticationFilterTest.java
+++ b/src/test/java/com/retrip/auth/infra/adapter/in/rest/filter/LoginAuthenticationFilterTest.java
@@ -1,6 +1,7 @@
 package com.retrip.auth.infra.adapter.in.rest.filter;
 
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.retrip.auth.application.in.request.LoginRequest;
 import com.retrip.auth.application.in.request.MemberCreateRequest;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -28,66 +30,49 @@ class LoginAuthenticationFilterTest extends BaseLoginAuthenticationTest {
     @Autowired
     private MockMvc mockMvc;
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Test
-     void 로그인_성공() throws Exception {
+    void 로그인_성공() throws Exception {
         memberRepository.save(member);
 
-        // given
         LoginRequest request = new LoginRequest("test@naver.com", "1234");
 
-        //when
-        // headers 생성
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("id", request.id());
-        headers.add("password", request.password());
-
-        // when & then
-        mockMvc.perform(get("/login")
+        mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .headers(headers))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").isBoolean())
-                .andExpect(jsonPath("$.status").isNotEmpty())
                 .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
                 .andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
     }
 
     @Test
     void 유저_생성_성공() throws Exception {
-        // given
-        MemberCreateRequest request = new MemberCreateRequest("test@naver.com", "1234", "test", null, null, true, false);
+        MemberCreateRequest request = new MemberCreateRequest("test@naver.com", "Test1234!", "test", null, null, null, true, false);
 
-        //when
-        String json = new ObjectMapper().writeValueAsString(request);
-
-        // when & then
         mockMvc.perform(post("/users")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(json)
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").isBoolean())
-                .andExpect(jsonPath("$.status").isNotEmpty())
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.id").isNotEmpty())
                 .andExpect(jsonPath("$.data.email").isNotEmpty());
     }
+
     @Test
     void 유저_수정_성공() throws Exception {
         memberRepository.save(member);
 
-        // given
-        MemberUpdateRequest request = new MemberUpdateRequest("1234", "1111", "수정 테스트", null, null);
-        //when
-        String json = new ObjectMapper().writeValueAsString(request);
+        // 로그인해서 토큰 획득
+        String accessToken = login("test@naver.com", "1234");
 
-        // when & then
+        MemberUpdateRequest request = new MemberUpdateRequest("1234", "Test1234!", "수정 테스트", null, null);
+
         mockMvc.perform(put("/users")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(json)
-                )
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").isBoolean())
-                .andExpect(jsonPath("$.status").isNotEmpty())
                 .andExpect(jsonPath("$.data.id").isNotEmpty())
                 .andExpect(jsonPath("$.data.email").isNotEmpty());
     }
@@ -96,19 +81,27 @@ class LoginAuthenticationFilterTest extends BaseLoginAuthenticationTest {
     void 유저_삭제_성공() throws Exception {
         memberRepository.save(member);
 
-        // given
-        MemberDeleteRequest request = new MemberDeleteRequest("1234");
-        //when
-        String json = new ObjectMapper().writeValueAsString(request);
+        // 로그인해서 토큰 획득
+        String accessToken = login("test@naver.com", "1234");
 
-        // when & then
+        MemberDeleteRequest request = new MemberDeleteRequest("1234");
+
         mockMvc.perform(delete("/users")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(json)
-                )
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+    }
+
+    private String login(String email, String password) throws Exception {
+        LoginRequest loginRequest = new LoginRequest(email, password);
+        MvcResult result = mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").isBoolean())
-                .andExpect(jsonPath("$.status").isNotEmpty())
-                .andExpect(jsonPath("$.message").isNotEmpty());
+                .andReturn();
+
+        JsonNode data = objectMapper.readTree(result.getResponse().getContentAsString()).get("data");
+        return data.get("accessToken").asText();
     }
 }

--- a/src/test/java/com/retrip/auth/infra/adapter/in/rest/filter/base/BaseLoginAuthenticationTest.java
+++ b/src/test/java/com/retrip/auth/infra/adapter/in/rest/filter/base/BaseLoginAuthenticationTest.java
@@ -39,7 +39,8 @@ public abstract class BaseLoginAuthenticationTest {
                 null,
                 null,
                 true,
-                false
+                false,
+                null
         );
     }
 }

--- a/src/test/java/com/retrip/auth/infra/adapter/in/rest/in/AuthControllerTest.java
+++ b/src/test/java/com/retrip/auth/infra/adapter/in/rest/in/AuthControllerTest.java
@@ -3,6 +3,7 @@ package com.retrip.auth.infra.adapter.in.rest.in;
 import com.retrip.auth.application.config.JwtProvider;
 import com.retrip.auth.application.in.AuthService;
 import com.retrip.auth.application.in.response.LoginResponse;
+import com.retrip.auth.application.out.repository.MemberRepository;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,9 @@ class AuthControllerTest {
 
     @MockBean
     private JwtProvider jwtProvider;
+
+    @MockBean
+    private MemberRepository memberRepository;
 
     @Test
     @DisplayName("토큰 재발급 API 성공 - 쿠키 설정 확인")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,72 @@
+token:
+  jwt:
+    private-key: MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCsW6GZ18buvwRzeDdzFr+AGNsoqGHPYBoEoF0+YvQl3lm26U7V8BNO3VP7WSbLHVt47UBSTtaEaENY3FOTa6pkSzGl8gEHVptrEqK6dI9HS4g7Nva5ZmeJ+9CjGDEd5x9xYouIrT7cy6bxvxR6Pw8+haXRmP5R4TzEjlyg5RKT5D7RsaWnyVeGV2KVqb/omUk5y+LAY5Nn50/sFKN0KHESrsm4cCrejZjQHoIjXrF4Zga2p8dkM00NGMvKBEz5gmOgrntLc84YJyZ5O+9xU3A7WSU4J7mY8NDARRzzKRMEXR4fwJH4AKPMs63BPHgrYYjGrk/HK4vGTupl119Ebm2HAgMBAAECggEAB0Zbf6D+FQqmofG43sM0NFsYOP2ZGfB+TflaJi11Yk8hw0N9X9tLvVWV213hHMvxlfI8TPJl7Ihyu0KaxnX8vFH416kWG7IEn6mAM9WCof7mp5/YxxeIQZM0NFtri027joTFy0WLXzS7Uv3T2/BjG3+hnENUYgQF6sKa10cD7eOvzRai569cKjCO9w3v2cB4wJJJug/D3vFKZCoux64rEUvK78hyq1cUfGQfO8J3Ga9jYaWswrYnjx4bzM0szGHc0FylpCY/0wYQg/B1q+UlVTlKSRYD7fZZ+xpVwDMZNfqB7wCLvtKBv6Y+YBku66fyAi++eDJ4K1lgJmuIqS4MDQKBgQDaHNQt9ARLgVDtpitjxrvmMkbkUOY7/o61sLKw/VwU1LA2QOTjUAekWGm5+K2KoC/edSlIKY+EiPyGfIkXv8etDeM4ujAlhaXaZ1j1+h+QymUYGrLiDE8VWKDzeulGOE+1Rv6dce9C3RSm08nEegzUWWeU/l7+6cRLWaNTa1uopQKBgQDKTCd1mwkBcwMMkCYIYBaQorOQSa9alczHkZFWEpMoqoDMe/dVFpMspW4EsBxZcDiGxhPkPTFS9NUYKd5U7tQhRkrOAhLXqzW+lLA/oSySROuk31xI5+c5fR0ebC+Q+U2RbXeGTBRRc2ibcvEC3bBLptEqTws7c9YEJKZFvz+5uwKBgQDIXt+Vb6xaaOwdxh/qQ3HuoZV6vc8kolAcHb2q1rY29MUEsk0TfjvnAMnv7MIQreQL63oHLxcHXIkQS2vuA2K+Whm5zWHZtpOMtpCFOEizTRveLvjSrRghtg/2XZ3bwnOHRzc1EKwKsur772hWNQGAOrnrqFtAtyR7TFe8lM3ZeQKBgFORbAeQOQMpQMwyzBNPpmKvY6AqYE76bPLQNoqo97On47cVStISlk+uMymqmrtzuVYrg1IY2URcsZ7exOKvGmB4ijRZ9PC04GnPQJO4gBIYeIPOZXAUpJdCEQJdTLUF175Iy0RmL0qKc18r91XowIgv7F4e8xPnQTTK8wkC/U87AoGBAIdbeUmFhl8gJpngh26bDF/lnMPQzIQr66R2vpGW+ttCiSRolMNkBY1zHGBS2ycDRjWeay1lLTvGaYR9GoL57/zyg9bfArPuHMA7LJzFZETE8DtCi4tA05/ObWukawJSZDIQRNyvVA6Ms8uEiPNyo7jrfMPgY1uKZoqkpMNS+mUR
+    public-key: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArFuhmdfG7r8Ec3g3cxa/gBjbKKhhz2AaBKBdPmL0Jd5ZtulO1fATTt1T+1kmyx1beO1AUk7WhGhDWNxTk2uqZEsxpfIBB1abaxKiunSPR0uIOzb2uWZnifvQoxgxHecfcWKLiK0+3Mum8b8Uej8PPoWl0Zj+UeE8xI5coOUSk+Q+0bGlp8lXhldilam/6JlJOcviwGOTZ+dP7BSjdChxEq7JuHAq3o2Y0B6CI16xeGYGtqfHZDNNDRjLygRM+YJjoK57S3POGCcmeTvvcVNwO1klOCe5mPDQwEUc8ykTBF0eH8CR+ACjzLOtwTx4K2GIxq5PxyuLxk7qZddfRG5thwIDAQAB
+    header: Authorization
+    prefix: Bearer
+    access:
+      expire-min: 30
+    refresh:
+      expire-min: 20160
+
+portone:
+  public:
+    store-id: test-store-id
+    channel-key: test-channel-key
+  api_secret: test-api-secret
+
+cloud:
+  aws:
+    region: ap-northeast-2
+    credentials:
+      access-key: test-access-key
+      secret-key: test-secret-key
+  s3:
+    bucket: retrip-media
+
+app:
+  frontend-callback-url: http://localhost:3000/auth/callback
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-google-client-id
+            client-secret: test-google-client-secret
+            scope:
+              - profile
+              - email
+            redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+          kakao:
+            client-id: test-kakao-client-id
+            client-secret: test-kakao-client-secret
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - account_email
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            client-name: Kakao
+          naver:
+            client-id: test-naver-client-id
+            client-secret: test-naver-client-secret
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+            redirect-uri: "http://localhost:8080/login/oauth2/code/naver"
+            client-name: Naver
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response


### PR DESCRIPTION
## Summary

- 카카오·구글·네이버 다중 소셜 로그인 3단계 연동 로직 구현
- 닉네임 필드 추가 및 소셜 유저 최초 로그인 비밀번호 설정 플로우 구현
- `POST /auth/reissue` 재발급 시 email/name/nickname 클레임 누락 버그 수정
- 배포 전 검증 버그 7건 수정 (입력값 검증, 에러코드 정비)
- API 명세서 v2.2 최신화 + Swagger withCredentials 안내 추가

## Changes

### feat
- 다중 소셜 로그인 연동 (MemberSocialProvider 신규 테이블, CustomOAuth2UserService, OAuthAttributes)
- 닉네임 필드 추가, 회원가입 요청·응답 반영
- 소셜 유저 최초 로그인 비밀번호 미설정 상태 처리 (hasPassword() 패턴)
- 회원 배치 조회 GET /users/members, 프로필 이미지 presigned URL

### fix
- AuthService.reissue(): principal UUID 문자열 → CustomUserDetails(member) 교체 → JWT 클레임 정상 포함
- Kakao 키 환경변수 복원 및 배포 워크플로우 OAuth2 Secrets 추가
- MemberCreateRequest: @Valid 활성화, name/gender/birthDate/password 형식 검증 추가
- MemberService: 약관 미동의(Member-009) 및 생년월일 범위(미래·100년 이상 과거) 검증 추가
- ChangePasswordRequest: currentPassword/newPassword @NotBlank @Pattern 추가
- MemberName: 이름 형식(한글·영문만, 최대 10자) 도메인 레벨 검증 추가
- MemberEmail: 공백 trim 처리 추가
- ErrorCode: Member-006~009 신규 추가
- ProfileController: 변수명 email → memberId 수정

### docs
- API 명세서 v2.2 (docs/spec.html, docs/index.html) 최신화
- Swagger: withCredentials 필수 설정 및 refreshToken 저장 금지 안내 추가
- travelStyles 필드가 ID가 아닌 이름 문자열 배열임을 명시

## ⚠️ 프론트엔드 필수 변경 사항

### Breaking Changes
| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| POST /login 요청 필드 | `email` | `id` |
| Refresh Token 관리 | 수동 저장 | HttpOnly 쿠키 자동 관리 |

### withCredentials 설정 필수
`/login` · `/auth/reissue` · `/auth/logout` 호출 시 쿠키 전송을 위해 반드시 설정 필요
- axios: `withCredentials: true`
- fetch: `credentials: 'include'`

### 신규 응답 필드
- `GET /users/me`: `nickname`, `isVerified`, `hasPassword`, `lastLoginProvider` 추가
- `GET /api/users/profile`: `nickname`, `hasPassword`, `lastLoginProvider`, `linkedProviders[]` 추가
- `PUT /api/users/profile`: 요청에 `nickname` 추가 가능, `travelStyles`는 이름 문자열 배열

### 신규 에러 코드
| 코드 | HTTP | 상황 |
|---|---|---|
| Member-006 | 400 | 본인인증 완료 후 이름/생년월일 변경 시도 |
| Member-007 | 403 | 소셜 전용 계정이 비밀번호 변경 시도 |
| Member-008 | 409 | 이미 비밀번호 있는 계정에 최초 설정 시도 |
| Member-009 | 400 | 필수 약관 미동의 |

## DB 변경 사항 (운영 배포 시 수동 적용 필요)

```sql
CREATE TABLE member_social_provider (...);
ALTER TABLE member DROP COLUMN provider_id;
```

## Test plan

- [ ] GitHub Actions 빌드 성공 확인
- [ ] EC2 테스트 서버 자동 배포 확인
- [ ] POST /login — 필드명 `id`로 요청, RT HttpOnly 쿠키 Set-Cookie 확인
- [ ] POST /auth/reissue — withCredentials 환경에서 쿠키 자동 전송 확인
- [ ] POST /auth/reissue — 재발급 토큰에 email/name/nickname 클레임 포함 확인
- [ ] 소셜 로그인 리다이렉트 플로우 정상 동작
- [ ] GET /users/me — nickname, isVerified, hasPassword, lastLoginProvider 응답 확인
- [ ] GET /api/users/profile — linkedProviders 배열 응답 확인
- [ ] POST /users — termsAgreed=false 시 Member-009 반환 확인
- [ ] PATCH /users/password — 소셜 전용 계정 시 Member-007(403) 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)