### PR TITLE
feat: 닉네임 중복 확인 API 추가 및 회원가입/프로필 수정 시 닉네임 유효성 검증

### DIFF
--- a/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
+++ b/src/main/java/com/retrip/auth/application/config/SecurityConfig.java
@@ -119,7 +119,7 @@ public class SecurityConfig {
                         .requestMatchers("/login/**", "/oauth2/**", "/auth/reissue", "/auth/logout", "/").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
                         // ✅ 추가: 본인인증 및 여행 스타일 조회 API 허용
-                        .requestMatchers(HttpMethod.GET, "/api/travel-styles").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/travel-styles", "/api/users/check-nickname").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/auth/verify-identity").authenticated()
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/retrip/auth/application/in/MemberService.java
+++ b/src/main/java/com/retrip/auth/application/in/MemberService.java
@@ -62,6 +62,11 @@ public class MemberService implements ManageMemberUseCase {
             throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
+        if (request.nickname() != null && !request.nickname().isBlank()
+                && memberRepository.existsByNicknameAndIsDeletedFalse(request.nickname())) {
+            throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
         Member member = memberRepository.save(request.to(encode));
 
         Authentication authentication = createAuthentication(member);

--- a/src/main/java/com/retrip/auth/application/out/repository/MemberRepository.java
+++ b/src/main/java/com/retrip/auth/application/out/repository/MemberRepository.java
@@ -20,6 +20,10 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
     // 추가: CI 중복 체크
     boolean existsByCi(String ci);
 
+    // 닉네임 중복 체크
+    boolean existsByNicknameAndIsDeletedFalse(String nickname);
+    Optional<Member> findByNicknameAndIsDeletedFalse(String nickname);
+
     @Query("SELECT m FROM Member m WHERE LOWER(m.name.value) LIKE LOWER(CONCAT('%', :name, '%')) AND m.isDeleted = false")
     List<Member> searchByNameContainingIgnoreCase(@Param("name") String name);
 

--- a/src/main/java/com/retrip/auth/application/service/ProfileService.java
+++ b/src/main/java/com/retrip/auth/application/service/ProfileService.java
@@ -12,6 +12,8 @@ import com.retrip.auth.domain.entity.MemberSocialProvider;
 import com.retrip.auth.domain.entity.MemberTravelStyle;
 import com.retrip.auth.domain.entity.TravelStyle;
 import com.retrip.auth.domain.exception.MemberNotFoundException;
+import com.retrip.auth.domain.exception.common.BusinessException;
+import com.retrip.auth.domain.exception.common.ErrorCode;
 import com.retrip.auth.domain.exception.common.InvalidValueException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +54,10 @@ public class ProfileService {
         Member member = memberRepository.findById(UUID.fromString(memberId))
                 .orElseThrow(MemberNotFoundException::new);
 
-        if (request.getNickname() != null) member.updateNickname(request.getNickname());
+        if (request.getNickname() != null) {
+            validateNicknameNotDuplicated(request.getNickname(), member.getId().toString());
+            member.updateNickname(request.getNickname());
+        }
         member.updateProfile(request.getBio(), request.getMbti(), request.getProfileImageUrl());
 
         if (request.getTravelStyles() != null) {
@@ -74,6 +79,16 @@ public class ProfileService {
         Member member = memberRepository.findById(UUID.fromString(memberId))
                 .orElseThrow(MemberNotFoundException::new);
         member.updateNotificationSettings(request.getEnabled());
+    }
+
+    public boolean isNicknameAvailable(String nickname) {
+        return !memberRepository.existsByNicknameAndIsDeletedFalse(nickname);
+    }
+
+    private void validateNicknameNotDuplicated(String nickname, String currentMemberId) {
+        memberRepository.findByNicknameAndIsDeletedFalse(nickname)
+                .filter(existing -> !existing.getId().toString().equals(currentMemberId))
+                .ifPresent(ignored -> { throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXISTS); });
     }
 
     private void updateTravelStyles(Member member, List<String> styleNames) {

--- a/src/main/java/com/retrip/auth/domain/exception/common/ErrorCode.java
+++ b/src/main/java/com/retrip/auth/domain/exception/common/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     SOCIAL_MEMBER_CANNOT_CHANGE_PASSWORD(HttpStatus.FORBIDDEN, "Member-007", "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
     PASSWORD_ALREADY_EXISTS(HttpStatus.CONFLICT, "Member-008", "이미 비밀번호가 설정된 계정입니다."),
     TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "Member-009", "필수 약관에 동의해야 합니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "Member-010", "이미 사용 중인 닉네임입니다."),
 
     EXTENSION_NOT_FOUND(BAD_REQUEST, "Image-001", "지원하지 않는 이미지 확장자입니다."),
     ;

--- a/src/main/java/com/retrip/auth/infra/adapter/in/rest/controller/ProfileController.java
+++ b/src/main/java/com/retrip/auth/infra/adapter/in/rest/controller/ProfileController.java
@@ -9,6 +9,8 @@ import com.retrip.auth.application.service.IdentityVerificationService;
 import com.retrip.auth.application.service.ProfileService;
 import com.retrip.auth.infra.adapter.in.rest.common.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -47,6 +49,16 @@ public class ProfileController {
         String memberId = userDetails.getUsername();
         ProfileResponse profile = profileService.updateProfile(memberId, request);
         return ApiResponse.ok(profile);
+    }
+
+    /**
+     * 닉네임 중복 확인 (비로그인 가능)
+     */
+    @GetMapping("/users/check-nickname")
+    public ApiResponse<Boolean> checkNickname(
+            @RequestParam @NotBlank @Size(max = 15) String nickname
+    ) {
+        return ApiResponse.ok(profileService.isNicknameAvailable(nickname));
     }
 
     /**


### PR DESCRIPTION
- GET /api/users/check-nickname 엔드포인트 추가 (비로그인 허용)
- MemberRepository에 닉네임 중복 체크 쿼리 메서드 추가
- ProfileService에 닉네임 중복 검증 로직 추가 (본인 닉네임 유지 허용)
- 회원가입 시 닉네임 명시 입력 시 중복 체크
- ErrorCode NICKNAME_ALREADY_EXISTS (Member-010, 409) 추가

## 🔍 PR 타입 선택

아래 타입 중 해당하는 하나를 선택해 주세요. 반드시 하나만 선택해 주세요.

- [ ] `feat`: 새로운 기능 추가
- [ ] `fix`: 버그 수정
- [ ] `docs`: 문서 수정
- [ ] `style`: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] `refactor`: 코드 리팩토링
- [ ] `test`: 테스트 코드 추가 또는 수정
- [ ] `chore`: 빌드 업무 수정, 패키지 매니저 수정 등 기타 작업


## 📝 변경 사항 요약

   - GET /api/users/check-nickname?nickname= 엔드포인트 추가 (비인증 허용)
   - 회원가입 시 닉네임 중복 검증 추가                                                                                                       
  - 프로필 수정 시 닉네임 중복 검증 추가 (본인 제외)
  - NICKNAME_ALREADY_EXISTS 에러코드 추가 (Member-010, 409 Conflict)

  ## Changed Files
  - ProfileController.java — GET /api/users/check-nickname 엔드포인트
  - ProfileService.java — isNicknameAvailable(), validateNicknameNotDuplicated()
  - MemberService.java — 회원가입 시 닉네임 중복 체크
  - MemberRepository.java — existsByNicknameAndIsDeletedFalse, findByNicknameAndIsDeletedFalse
  - ErrorCode.java — NICKNAME_ALREADY_EXISTS 추가
  - SecurityConfig.java — /api/users/check-nickname permitAll 추가

  ## Test plan
  - [ ] GET /api/users/check-nickname?nickname=존재하는닉네임 → false 반환
  - [ ] GET /api/users/check-nickname?nickname=없는닉네임 → true 반환
  - [ ] 회원가입 시 중복 닉네임 입력 → 409 에러
  - [ ] 프로필 수정 시 타인과 동일한 닉네임 → 409 에러
  - [ ] 프로필 수정 시 본인 현재 닉네임으로 수정 → 정상 처리


## 🛠 관련 이슈

Resolves: #123  
Ref: #456  
Related to: #48, #45
close: #번호

### **추가 설명 (선택 사항)**

변경 사항에 대한 추가 설명을 작성해 주세요.
