### PR TITLE
fix: 소셜 로그인 OAuth2 prod 환경 설정 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,30 @@ jobs:
           docker stop auth-server || true
           docker rm auth-server || true
           docker pull bjisu/auth-server:latest
-          docker run -d --name auth-server -p 8080:8080 bjisu/auth-server:latest
+          docker run -d --name auth-server -p 8081:8080 \
+            -e SPRING_PROFILES_ACTIVE=prod \
+            -e APP_BASE_URL=${{ secrets.APP_BASE_URL }} \
+            -e JWT_PRIVATE_KEY=${{ secrets.JWT_PRIVATE_KEY }} \
+            -e JWT_PUBLIC_KEY=${{ secrets.JWT_PUBLIC_KEY }} \
+            -e "DB_URL=jdbc:mysql://${{ secrets.DB_HOST }}:${{ secrets.DB_PORT }}/${{ secrets.AUTH_DB_NAME }}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true" \
+            -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
+            -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+            -e GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} \
+            -e GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }} \
+            -e KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }} \
+            -e KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }} \
+            -e NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} \
+            -e NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} \
+            -e MAIL_USERNAME=${{ secrets.MAIL_USERNAME }} \
+            -e MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }} \
+            -e FRONTEND_CALLBACK_URL=${{ secrets.FRONTEND_CALLBACK_URL || 'https://retrip-web.vercel.app/auth/callback' }} \
+            -e FRONTEND_PASSWORD_RESET_URL=${{ secrets.FRONTEND_PASSWORD_RESET_URL || 'https://retrip-web.vercel.app/reset-password' }} \
+            -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
+            -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            -e PORTONE_STORE_ID=${{ secrets.PORTONE_STORE_ID }} \
+            -e PORTONE_CHANNEL_KEY=${{ secrets.PORTONE_CHANNEL_KEY }} \
+            -e PORTONE_API_SECRET=${{ secrets.PORTONE_API_SECRET }} \
+            bjisu/auth-server:latest
 
     - name: IP 제거 (SSH 포트)
       if: ${{ always() }}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,3 +1,10 @@
+server:
+  forward-headers-strategy: framework
+
+app:
+  cookie:
+    secure: false
+
 spring:
   datasource:
     url: ${DB_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,7 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID:your-google-client-id}
             client-secret: ${GOOGLE_CLIENT_SECRET:your-google-client-secret}
             scope:
+              - openid
               - profile
               - email
             redirect-uri: "${APP_BASE_URL:http://localhost:8080}/login/oauth2/code/google"
@@ -36,6 +37,7 @@ spring:
             authorization-grant-type: authorization_code
             scope:
               - profile_nickname
+              - account_email
             redirect-uri: "${APP_BASE_URL:http://localhost:8080}/login/oauth2/code/kakao"
             client-name: Kakao
 


### PR DESCRIPTION
## Summary
- Google scope에 `openid` 추가, Kakao scope에 `account_email` 추가
- `application-prod.yml`에 `forward-headers-strategy: framework` 추가 (리버스 프록시 환경에서 HTTPS 인식)
- `application-prod.yml`에 `cookie.secure: false` 추가 (HTTP 환경에서 refresh token 쿠키 정상 전달)
- `deploy.yml` docker run에 `SPRING_PROFILES_ACTIVE=prod` 및 모든 환경변수 `-e` 플래그로 주입 (기존엔 아무것도 전달 안 됨)
- docker 포트 매핑 `8080:8080` → `8081:8080` 수정 (소셜 redirect URI 등록 포트와 일치)
- `DB_URL`을 `DB_HOST`, `DB_PORT`, `AUTH_DB_NAME` 시크릿 조합으로 구성

## 배포 전 GitHub Secrets 확인
- `APP_BASE_URL` 값을 `http://15-164-112-64.nip.io:8081` 로 수정
- `FRONTEND_CALLBACK_URL` 추가 → `https://retrip-web.vercel.app/auth/callback`

## Test plan
- [ ] Naver 소셜 로그인 정상 동작 확인
- [ ] Kakao 소셜 로그인 정상 동작 확인 (account_email scope로 실제 이메일 수신 확인)
- [ ] 일반 로그인 후 refresh token 쿠키 정상 저장 확인
- [ ] 토큰 재발급(/auth/reissue) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)