### PR TITLE
test: 이메일 인증 및 CI 미매칭 OTP 플로우 테스트

### DIFF
--- a/src/main/resources/static/test.html
+++ b/src/main/resources/static/test.html
@@ -179,6 +179,30 @@
             </div>
         </div>
 
+ㅅㅅㄷ        <!-- 회원가입 이메일 인증 (신규) -->
+        <div class="card" style="border-left: 3px solid #667eea;">
+            <h3><span class="badge badge-post">POST /auth/email/send-code</span> &nbsp; <span class="badge badge-post">POST /auth/email/verify-code</span> 회원가입 이메일 인증 <span style="font-size:10px;color:#f59e0b;font-weight:600;">NEW</span></h3>
+            <div class="desc">회원가입 전 이메일 인증 필수. ① 코드 발송 → ② 코드 확인 (10분 유효) → 30분 내에 회원가입 완료.</div>
+            <div class="info-box">이미 가입된 이메일이면 409, 탈퇴한 이메일이면 400 반환.</div>
+            <label>이메일</label>
+            <input type="email" id="emailVerifEmail" value="user@test.com" oninput="syncSignupEmail(this.value)">
+            <button class="btn btn-primary btn-block" onclick="sendSignupEmailCode()">① 인증코드 발송</button>
+            <div class="result-box" id="sendSignupCodeResult">
+                <div class="result-header"><span class="status" id="sendSignupCodeStatus"></span><span>POST /auth/email/send-code</span></div>
+                <div class="result-body" id="sendSignupCodeBody"></div>
+            </div>
+            <div style="margin-top:12px;">
+                <label>인증코드 (6자리, 메일 확인)</label>
+                <input type="text" id="emailVerifCode" placeholder="123456" maxlength="6">
+                <button class="btn btn-success btn-block" onclick="verifySignupEmailCode()">② 인증코드 확인</button>
+                <div class="result-box" id="verifySignupCodeResult">
+                    <div class="result-header"><span class="status" id="verifySignupCodeStatus"></span><span>POST /auth/email/verify-code</span></div>
+                    <div class="result-body" id="verifySignupCodeBody"></div>
+                </div>
+                <div id="emailVerifSuccessMsg" style="display:none;margin-top:8px;font-size:12px;color:#10b981;font-weight:600;">✅ 이메일 인증 완료! 30분 내에 위 회원가입 카드에서 가입을 완료하세요.</div>
+            </div>
+        </div>
+
     </div>
 </div>
 
@@ -700,6 +724,24 @@
                 <div class="result-header"><span class="status" id="findEmailStatus"></span><span>POST /auth/find-email</span></div>
                 <div class="result-body" id="findEmailBody"></div>
             </div>
+
+            <!-- CI 미매칭 OTP 플로우 (202 응답 시 자동 표시) NEW -->
+            <div id="findEmailOtpSection" style="display:none;margin-top:16px;border-top:1px solid #e2e8f0;padding-top:14px;">
+                <div class="warn-box">CI 미매칭: 본인인증 정보와 연결된 계정을 이름+생년월일로 탐색했습니다.<br>등록된 이메일로 OTP를 발송해 이메일 소유권을 확인합니다.</div>
+                <button class="btn btn-primary btn-block" onclick="sendFindEmailOtp()">③ OTP 발송 (등록 이메일로)</button>
+                <div class="result-box" id="sendFindEmailOtpResult">
+                    <div class="result-header"><span class="status" id="sendFindEmailOtpStatus"></span><span>POST /auth/find-email/send-code</span></div>
+                    <div class="result-body" id="sendFindEmailOtpBody"></div>
+                </div>
+                <label style="margin-top:10px;">OTP 코드 (6자리, 메일 확인)</label>
+                <input type="text" id="findEmailOtpCode" placeholder="123456" maxlength="6">
+                <button class="btn btn-success btn-block" onclick="confirmFindEmailOtp()">④ OTP 확인 → 이메일 반환</button>
+                <div class="result-box" id="confirmFindEmailOtpResult">
+                    <div class="result-header"><span class="status" id="confirmFindEmailOtpStatus"></span><span>POST /auth/find-email/confirm</span></div>
+                    <div class="result-body" id="confirmFindEmailOtpBody"></div>
+                </div>
+                <div id="findEmailOtpSuccessMsg" style="display:none;margin-top:8px;font-size:13px;color:#10b981;font-weight:600;"></div>
+            </div>
         </div>
 
         <!-- 비밀번호 재설정 - 이메일 경로 -->
@@ -741,6 +783,26 @@
                 <div class="result-header"><span class="status" id="resetByVerifStatus"></span><span>POST /auth/password-reset/by-verification</span></div>
                 <div class="result-body" id="resetByVerifBody"></div>
             </div>
+
+            <!-- CI 미매칭 OTP 플로우 (202 응답 시 자동 표시) NEW -->
+            <div id="resetVerifOtpSection" style="display:none;margin-top:16px;border-top:1px solid #e2e8f0;padding-top:14px;">
+                <div class="warn-box">CI 미매칭: 이름+생년월일로 계정을 탐색했습니다.<br>가입 시 사용한 이메일을 입력하면 OTP로 소유권을 확인합니다.</div>
+                <label>가입 이메일 (소유권 확인용)</label>
+                <input type="email" id="resetVerifOtpEmail" placeholder="가입할 때 사용한 이메일">
+                <button class="btn btn-primary btn-block" onclick="sendResetVerifOtp()">③ OTP 발송</button>
+                <div class="result-box" id="sendResetVerifOtpResult">
+                    <div class="result-header"><span class="status" id="sendResetVerifOtpStatus"></span><span>POST /auth/password-reset/by-verification/send-code</span></div>
+                    <div class="result-body" id="sendResetVerifOtpBody"></div>
+                </div>
+                <label style="margin-top:10px;">OTP 코드 (6자리, 메일 확인)</label>
+                <input type="text" id="resetVerifOtpCode" placeholder="123456" maxlength="6">
+                <button class="btn btn-success btn-block" onclick="confirmResetVerifOtp()">④ OTP 확인 → 재설정 토큰 발급</button>
+                <div class="result-box" id="confirmResetVerifOtpResult">
+                    <div class="result-header"><span class="status" id="confirmResetVerifOtpStatus"></span><span>POST /auth/password-reset/by-verification/confirm</span></div>
+                    <div class="result-body" id="confirmResetVerifOtpBody"></div>
+                </div>
+            </div>
+
             <div style="margin-top:16px;border-top:1px solid #e2e8f0;padding-top:14px;">
                 <div class="desc">위에서 발급된 토큰이 자동 입력됩니다.</div>
                 <label>재설정 토큰</label>
@@ -768,7 +830,9 @@
         storeId: '',
         channelKey: '',
         presignedUrl: '',
-        readImageUrl: ''
+        readImageUrl: '',
+        findEmailSessionId: '',
+        resetVerifSessionId: ''
     };
 
     // ===================== CONFIG =====================
@@ -834,6 +898,28 @@
         } catch(e) {
             if (resultId) showResult(resultId, '네트워크 오류 ❌', e.message, true);
             return { ok: false, status: 0, data: e.message };
+        }
+    }
+
+    // ===================== 섹션 1 — 이메일 인증 =====================
+    function syncSignupEmail(val) {
+        document.getElementById('signupEmail').value = val;
+    }
+
+    async function sendSignupEmailCode() {
+        const email = document.getElementById('emailVerifEmail').value.trim();
+        if (!email) { alert('이메일을 입력하세요.'); return; }
+        document.getElementById('emailVerifSuccessMsg').style.display = 'none';
+        await api('POST', '/auth/email/send-code', { email }, 'sendSignupCode', false);
+    }
+
+    async function verifySignupEmailCode() {
+        const email = document.getElementById('emailVerifEmail').value.trim();
+        const code  = document.getElementById('emailVerifCode').value.trim();
+        if (!email || !code) { alert('이메일과 인증코드를 모두 입력하세요.'); return; }
+        const r = await api('POST', '/auth/email/verify-code', { email, code }, 'verifySignupCode', false);
+        if (r.status === 204 || r.ok) {
+            document.getElementById('emailVerifSuccessMsg').style.display = 'block';
         }
     }
 
@@ -1272,15 +1358,47 @@
     }
 
     async function doFindEmail(impUid) {
+        STATE.findEmailSessionId = '';
+        document.getElementById('findEmailOtpSection').style.display = 'none';
+        document.getElementById('findEmailOtpSuccessMsg').style.display = 'none';
+
         const r = await api('POST', '/auth/find-email', { impUid }, 'findEmail', false);
         const msg = document.getElementById('findEmailMsg');
-        if (r.ok && r.data?.data) {
+
+        if (r.status === 200 && r.data?.data?.maskedEmail) {
             const d = r.data.data;
             msg.style.display = 'block';
             msg.style.color = '#10b981';
             msg.textContent = `✅ 이메일: ${d.maskedEmail}${d.isNowVerified ? '  (이번에 본인인증이 처음 연결됐습니다)' : ''}`;
+        } else if (r.status === 202 && r.data?.data?.sessionId) {
+            // CI 미매칭 → OTP 플로우
+            STATE.findEmailSessionId = r.data.data.sessionId;
+            msg.style.display = 'block';
+            msg.style.color = '#f59e0b';
+            msg.textContent = '⚠️ CI 미매칭: 아래 단계에서 이메일로 OTP를 발송해 소유권을 확인하세요.';
+            document.getElementById('findEmailOtpSection').style.display = 'block';
         } else {
             msg.style.display = 'none';
+        }
+    }
+
+    async function sendFindEmailOtp() {
+        if (!STATE.findEmailSessionId) { alert('먼저 본인인증을 진행하세요.'); return; }
+        await api('POST', '/auth/find-email/send-code', { sessionId: STATE.findEmailSessionId }, 'sendFindEmailOtp', false);
+    }
+
+    async function confirmFindEmailOtp() {
+        if (!STATE.findEmailSessionId) { alert('먼저 본인인증을 진행하세요.'); return; }
+        const code = document.getElementById('findEmailOtpCode').value.trim();
+        if (!code) { alert('OTP 코드를 입력하세요.'); return; }
+        const r = await api('POST', '/auth/find-email/confirm',
+            { sessionId: STATE.findEmailSessionId, code }, 'confirmFindEmailOtp', false);
+        if (r.ok && r.data?.data?.maskedEmail) {
+            const d = r.data.data;
+            const successMsg = document.getElementById('findEmailOtpSuccessMsg');
+            successMsg.style.display = 'block';
+            successMsg.textContent = `✅ 이메일: ${d.maskedEmail}  (본인인증이 계정에 연결됐습니다)`;
+            STATE.findEmailSessionId = '';
         }
     }
 
@@ -1305,14 +1423,45 @@
     }
 
     async function doIssueResetTokenByVerif(impUid) {
+        STATE.resetVerifSessionId = '';
+        document.getElementById('resetVerifOtpSection').style.display = 'none';
+
         const r = await api('POST', '/auth/password-reset/by-verification', { impUid }, 'resetByVerif', false);
-        if (r.ok && r.data?.data?.resetToken) {
+
+        if (r.status === 200 && r.data?.data?.resetToken) {
             const token = r.data.data.resetToken;
-            document.getElementById('resetVerifImpUid').value = impUid;
             document.getElementById('resetTokenFromVerif').value = token;
             const d = document.getElementById('resetVerifTokenDisplay');
             d.style.display = 'block';
             d.textContent = '발급된 토큰: ' + token;
+        } else if (r.status === 202 && r.data?.data?.sessionId) {
+            // CI 미매칭 → OTP 플로우
+            STATE.resetVerifSessionId = r.data.data.sessionId;
+            document.getElementById('resetVerifOtpSection').style.display = 'block';
+        }
+    }
+
+    async function sendResetVerifOtp() {
+        if (!STATE.resetVerifSessionId) { alert('먼저 본인인증을 진행하세요.'); return; }
+        const email = document.getElementById('resetVerifOtpEmail').value.trim();
+        if (!email) { alert('가입 이메일을 입력하세요.'); return; }
+        await api('POST', '/auth/password-reset/by-verification/send-code',
+            { sessionId: STATE.resetVerifSessionId, email }, 'sendResetVerifOtp', false);
+    }
+
+    async function confirmResetVerifOtp() {
+        if (!STATE.resetVerifSessionId) { alert('먼저 본인인증을 진행하세요.'); return; }
+        const code = document.getElementById('resetVerifOtpCode').value.trim();
+        if (!code) { alert('OTP 코드를 입력하세요.'); return; }
+        const r = await api('POST', '/auth/password-reset/by-verification/confirm',
+            { sessionId: STATE.resetVerifSessionId, code }, 'confirmResetVerifOtp', false);
+        if (r.ok && r.data?.data?.resetToken) {
+            const token = r.data.data.resetToken;
+            document.getElementById('resetTokenFromVerif').value = token;
+            const d = document.getElementById('resetVerifTokenDisplay');
+            d.style.display = 'block';
+            d.textContent = '발급된 토큰: ' + token + ' (이제 아래에서 비밀번호 재설정을 진행하세요)';
+            STATE.resetVerifSessionId = '';
         }
     }
 

--- a/src/test/java/com/retrip/auth/application/service/FindAccountServiceTest.java
+++ b/src/test/java/com/retrip/auth/application/service/FindAccountServiceTest.java
@@ -3,12 +3,14 @@ package com.retrip.auth.application.service;
 import com.retrip.auth.application.dto.CertificationInfo;
 import com.retrip.auth.application.dto.response.FindEmailResponse;
 import com.retrip.auth.application.dto.response.PasswordResetTokenResponse;
+import com.retrip.auth.application.dto.response.VerificationPendingResponse;
 import com.retrip.auth.application.out.repository.MemberRepository;
 import com.retrip.auth.application.out.repository.PasswordResetTokenRepository;
-import com.retrip.auth.domain.entity.PasswordResetToken;
+import com.retrip.auth.application.out.repository.PortOneVerificationSessionRepository;
 import com.retrip.auth.application.service.recovery.PortOneVerificationStrategy;
-import com.retrip.auth.application.service.recovery.VerificationResult;
 import com.retrip.auth.domain.entity.Member;
+import com.retrip.auth.domain.entity.PasswordResetToken;
+import com.retrip.auth.domain.entity.PortOneVerificationSession;
 import com.retrip.auth.domain.exception.common.BusinessException;
 import com.retrip.auth.infra.adapter.out.external.PortOneApiClient;
 import jakarta.transaction.Transactional;
@@ -21,13 +23,14 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.ArgumentMatchers.any;
 
 @SpringBootTest
 @Transactional
@@ -36,17 +39,21 @@ class FindAccountServiceTest {
     @Autowired FindAccountService findAccountService;
     @Autowired MemberRepository memberRepository;
     @Autowired PasswordResetTokenRepository resetTokenRepository;
+    @Autowired PortOneVerificationSessionRepository sessionRepository;
     @Autowired PasswordEncoder passwordEncoder;
 
-    // PortOne HTTP 호출 차단
     @MockBean PortOneApiClient portOneApiClient;
     @MockBean PortOneVerificationStrategy portOneStrategy;
-    // Gmail SMTP 연결 차단
     @MockBean JavaMailSender javaMailSender;
 
-    private static final CertificationInfo DUMMY_CERT = CertificationInfo.builder()
+    private static final CertificationInfo CERT_WITH_CI = CertificationInfo.builder()
             .name("홍길동").gender("MALE").birthday("1990-01-01")
-            .uniqueKey("ci-dummy").uniqueInSite("di-dummy")
+            .uniqueKey("ci-test").uniqueInSite("di-test")
+            .build();
+
+    private static final CertificationInfo CERT_WITHOUT_CI = CertificationInfo.builder()
+            .name("홍길동").gender("MALE").birthday("1990-01-01")
+            .uniqueKey(null).uniqueInSite(null)
             .build();
 
     private Member localMember;
@@ -61,34 +68,115 @@ class FindAccountServiceTest {
         socialMember = memberRepository.save(Member.createSocialMember(
                 "김소셜", "social@example.com", "google"
         ));
-
-        // PortOne HTTP 호출은 항상 DUMMY_CERT 반환
-        given(portOneApiClient.getCertificationInfo(anyString())).willReturn(DUMMY_CERT);
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // 아이디 찾기
+    // 아이디 찾기 - CI 매칭 경로
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
-    void 아이디찾기_기존인증사용자_isNowVerified_false() {
-        given(portOneStrategy.findMemberByCert(any())).willReturn(new VerificationResult(localMember, false));
+    void 아이디찾기_CI매칭_즉시이메일반환() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.of(localMember));
 
-        FindEmailResponse response = findAccountService.findEmailByVerification("imp_test");
+        Object result = findAccountService.findEmailByVerification("imp_test");
 
+        assertThat(result).isInstanceOf(FindEmailResponse.class);
+        FindEmailResponse response = (FindEmailResponse) result;
         assertThat(response.maskedEmail()).endsWith("@example.com");
-        assertThat(response.maskedEmail()).doesNotContain("local@");
         assertThat(response.maskedEmail()).contains("*");
         assertThat(response.isNowVerified()).isFalse();
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // 아이디 찾기 - CI 미매칭 → OTP 플로우
+    // ─────────────────────────────────────────────────────────────────────────
+
     @Test
-    void 아이디찾기_신규인증사용자_isNowVerified_true() {
-        given(portOneStrategy.findMemberByCert(any())).willReturn(new VerificationResult(localMember, true));
+    void 아이디찾기_CI미매칭_세션반환() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.empty());
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(localMember));
 
-        FindEmailResponse response = findAccountService.findEmailByVerification("imp_test");
+        Object result = findAccountService.findEmailByVerification("imp_test");
 
-        assertThat(response.isNowVerified()).isTrue();
+        assertThat(result).isInstanceOf(VerificationPendingResponse.class);
+        VerificationPendingResponse pending = (VerificationPendingResponse) result;
+        assertThat(pending.sessionId()).isNotBlank();
+        assertThat(sessionRepository.findById(pending.sessionId())).isPresent();
+    }
+
+    @Test
+    void 아이디찾기_CI없음_세션반환() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITHOUT_CI);
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(localMember));
+
+        Object result = findAccountService.findEmailByVerification("imp_test");
+
+        assertThat(result).isInstanceOf(VerificationPendingResponse.class);
+    }
+
+    @Test
+    void 아이디찾기_후보없음_예외() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITHOUT_CI);
+        given(portOneStrategy.findCandidates(anyString(), anyString())).willReturn(List.of());
+
+        assertThatThrownBy(() -> findAccountService.findEmailByVerification("imp_test"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("계정을 찾을 수 없습니다");
+    }
+
+    @Test
+    void 아이디찾기_OTP발송_성공() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.empty());
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(localMember));
+
+        VerificationPendingResponse pending = (VerificationPendingResponse) findAccountService.findEmailByVerification("imp_test");
+
+        findAccountService.sendFindEmailCode(pending.sessionId());
+
+        then(javaMailSender).should().send(any(org.springframework.mail.SimpleMailMessage.class));
+        PortOneVerificationSession session = sessionRepository.findById(pending.sessionId()).orElseThrow();
+        assertThat(session.getEmailCode()).isNotBlank();
+    }
+
+    @Test
+    void 아이디찾기_OTP확인_성공_이메일반환() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.empty());
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(localMember));
+
+        VerificationPendingResponse pending = (VerificationPendingResponse) findAccountService.findEmailByVerification("imp_test");
+        findAccountService.sendFindEmailCode(pending.sessionId());
+
+        String code = sessionRepository.findById(pending.sessionId()).orElseThrow().getEmailCode();
+        FindEmailResponse result = findAccountService.confirmFindEmail(pending.sessionId(), code);
+
+        assertThat(result.maskedEmail()).endsWith("@example.com");
+        assertThat(result.isNowVerified()).isTrue();
+        assertThat(sessionRepository.findById(pending.sessionId()).orElseThrow().isUsed()).isTrue();
+    }
+
+    @Test
+    void 아이디찾기_OTP틀림_예외() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.empty());
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(localMember));
+
+        VerificationPendingResponse pending = (VerificationPendingResponse) findAccountService.findEmailByVerification("imp_test");
+        findAccountService.sendFindEmailCode(pending.sessionId());
+
+        assertThatThrownBy(() -> findAccountService.confirmFindEmail(pending.sessionId(), "000000"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("올바르지 않습니다");
+    }
+
+    @Test
+    void 아이디찾기_OTP발송_세션없음_예외() {
+        assertThatThrownBy(() -> findAccountService.sendFindEmailCode("non-existent-session"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("인증 세션을 찾을 수 없");
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -96,22 +184,92 @@ class FindAccountServiceTest {
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
-    void 비밀번호재설정_본인인증_토큰발급_성공() {
-        given(portOneStrategy.findMemberByCert(any())).willReturn(new VerificationResult(localMember, false));
+    void 비밀번호재설정_CI매칭_즉시토큰발급() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.of(localMember));
 
-        PasswordResetTokenResponse response = findAccountService.issueResetTokenByVerification("imp_test");
+        Object result = findAccountService.issueResetTokenByVerification("imp_test");
 
+        assertThat(result).isInstanceOf(PasswordResetTokenResponse.class);
+        PasswordResetTokenResponse response = (PasswordResetTokenResponse) result;
         assertThat(response.resetToken()).isNotBlank();
         assertThat(resetTokenRepository.findByToken(response.resetToken())).isPresent();
     }
 
     @Test
-    void 비밀번호재설정_본인인증_소셜전용계정_실패() {
-        given(portOneStrategy.findMemberByCert(any())).willReturn(new VerificationResult(socialMember, false));
+    void 비밀번호재설정_CI미매칭_세션반환() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.empty());
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(localMember));
+
+        Object result = findAccountService.issueResetTokenByVerification("imp_test");
+
+        assertThat(result).isInstanceOf(VerificationPendingResponse.class);
+    }
+
+    @Test
+    void 비밀번호재설정_CI매칭_소셜전용계정_예외() {
+        given(portOneStrategy.getCertificationInfo("imp_social")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.of(socialMember));
 
         assertThatThrownBy(() -> findAccountService.issueResetTokenByVerification("imp_social"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("소셜");
+    }
+
+    @Test
+    void 비밀번호재설정_CI미매칭_소셜전용계정_예외() {
+        given(portOneStrategy.getCertificationInfo("imp_social")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.empty());
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(socialMember));
+
+        assertThatThrownBy(() -> findAccountService.issueResetTokenByVerification("imp_social"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("소셜");
+    }
+
+    @Test
+    void 비밀번호재설정_OTP발송_이메일검증_성공() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.empty());
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(localMember));
+
+        VerificationPendingResponse pending = (VerificationPendingResponse) findAccountService.issueResetTokenByVerification("imp_test");
+
+        findAccountService.sendPasswordResetCode(pending.sessionId(), "local@example.com");
+
+        then(javaMailSender).should().send(any(org.springframework.mail.SimpleMailMessage.class));
+        PortOneVerificationSession session = sessionRepository.findById(pending.sessionId()).orElseThrow();
+        assertThat(session.getEmailCode()).isNotBlank();
+    }
+
+    @Test
+    void 비밀번호재설정_OTP발송_이메일불일치_예외() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.empty());
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(localMember));
+
+        VerificationPendingResponse pending = (VerificationPendingResponse) findAccountService.issueResetTokenByVerification("imp_test");
+
+        assertThatThrownBy(() -> findAccountService.sendPasswordResetCode(pending.sessionId(), "other@example.com"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("이메일이 등록된 정보와 일치하지 않습니다");
+    }
+
+    @Test
+    void 비밀번호재설정_OTP확인_성공_토큰발급() {
+        given(portOneStrategy.getCertificationInfo("imp_test")).willReturn(CERT_WITH_CI);
+        given(portOneStrategy.findByCi("ci-test")).willReturn(Optional.empty());
+        given(portOneStrategy.findCandidates("홍길동", "1990-01-01")).willReturn(List.of(localMember));
+
+        VerificationPendingResponse pending = (VerificationPendingResponse) findAccountService.issueResetTokenByVerification("imp_test");
+        findAccountService.sendPasswordResetCode(pending.sessionId(), "local@example.com");
+
+        String code = sessionRepository.findById(pending.sessionId()).orElseThrow().getEmailCode();
+        PasswordResetTokenResponse result = findAccountService.confirmPasswordReset(pending.sessionId(), code);
+
+        assertThat(result.resetToken()).isNotBlank();
+        assertThat(resetTokenRepository.findByToken(result.resetToken())).isPresent();
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -140,7 +298,7 @@ class FindAccountServiceTest {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // 비밀번호 재설정 (토큰 검증 + 새 비밀번호 저장)
+    // 비밀번호 재설정 - 토큰 검증 + 새 비밀번호 저장
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
@@ -155,14 +313,12 @@ class FindAccountServiceTest {
     }
 
     @Test
-    void 비밀번호재설정_성공_기존세션_무효화() {
-        // 비밀번호 재설정 후 RefreshToken이 삭제되는지 확인
+    void 비밀번호재설정_성공_토큰_used_마킹() {
         findAccountService.sendPasswordResetEmail("local@example.com");
         String token = resetTokenRepository.findAll().get(0).getToken();
 
         findAccountService.resetPassword(token, "NewPass1!");
 
-        // 토큰이 used 상태로 변경됐는지 확인
         PasswordResetToken used = resetTokenRepository.findByToken(token).orElseThrow();
         assertThat(used.isUsed()).isTrue();
     }
@@ -189,7 +345,6 @@ class FindAccountServiceTest {
     void 비밀번호재설정_이미사용된토큰_실패() {
         findAccountService.sendPasswordResetEmail("local@example.com");
         String token = resetTokenRepository.findAll().get(0).getToken();
-
         findAccountService.resetPassword(token, "NewPass1!");
 
         assertThatThrownBy(() -> findAccountService.resetPassword(token, "NewPass2!"))
@@ -198,12 +353,12 @@ class FindAccountServiceTest {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // 이메일 마스킹 로직 검증
+    // 이메일 마스킹 로직
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
     void 이메일마스킹_짧은로컬파트() {
-        FindEmailResponse response = FindEmailResponse.of("ab@test.com", false);
+        FindEmailResponse response = FindEmailResponse.of("ab@test.com", List.of("local"), false);
         assertThat(response.maskedEmail()).startsWith("a");
         assertThat(response.maskedEmail()).contains("*");
         assertThat(response.maskedEmail()).endsWith("@test.com");
@@ -211,7 +366,7 @@ class FindAccountServiceTest {
 
     @Test
     void 이메일마스킹_긴로컬파트() {
-        FindEmailResponse response = FindEmailResponse.of("hello@test.com", false);
+        FindEmailResponse response = FindEmailResponse.of("hello@test.com", List.of("local"), false);
         assertThat(response.maskedEmail()).startsWith("hel");
         assertThat(response.maskedEmail()).endsWith("@test.com");
         assertThat(response.maskedEmail()).contains("**");


### PR DESCRIPTION
## Summary

- `test.html`에 회원가입 이메일 인증 카드 추가 (`POST /auth/email/send-code`, `/verify-code`)
- 아이디 찾기 CI 미매칭(202) 응답 시 OTP 섹션 자동 표시 및 `/find-email/send-code`, `/find-email/confirm` 연동
- 비밀번호 재설정 by-verification CI 미매칭(202) 응답 시 OTP 섹션 자동 표시 및 `/by-verification/send-code`, `/confirm` 연동
- `FindAccountServiceTest` 를 새 `portOneStrategy` API(`getCertificationInfo` / `findByCi` / `findCandidates`) 기반으로 재작성, CI 매칭·미매칭·OTP 플로우 케이스 추가

## Test plan

- [ ] `test.html` 접속 후 회원가입 이메일 인증 카드에서 인증코드 발송/확인 → 204 확인
- [ ] 인증 완료 후 회원가입 → 성공 확인
- [ ] 이미 가입된 이메일로 인증코드 발송 → 409 확인
- [ ] 섹션 15 아이디 찾기: CI 매칭 → 200 이메일 즉시 반환 확인
- [ ] 섹션 15 아이디 찾기: CI 미매칭 → 202 → OTP 섹션 자동 표시 → OTP 발송/확인 → 이메일 반환 확인
- [ ] 섹션 15 비밀번호 재설정(본인인증): CI 미매칭 → 202 → OTP 섹션 → 토큰 발급 → 비밀번호 재설정 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)